### PR TITLE
Add map controls, style switching, and interactive marker placement

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -66,6 +66,34 @@ body, html, #root {
 .mapboxgl-ctrl-group button {
   border-radius: var(--plk-radius-lg) !important;
 }
+.mapboxgl-ctrl-scale {
+  background: rgba(255, 255, 255, 0.85) !important;
+  backdrop-filter: blur(4px);
+  border-color: var(--plk-rule-strong) !important;
+  font-family: var(--plk-font-mono) !important;
+  font-size: 10px !important;
+  letter-spacing: 0.08em !important;
+  color: var(--plk-charcoal) !important;
+  border-radius: var(--plk-radius) !important;
+  padding: 2px 6px !important;
+}
+
+/* Geocoder collapsed look */
+.mapboxgl-ctrl-geocoder {
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06), 0 0 0 1px var(--plk-rule-strong) !important;
+  border-radius: var(--plk-radius-lg) !important;
+  font-family: var(--plk-font-body) !important;
+  min-width: 36px !important;
+}
+.mapboxgl-ctrl-geocoder--input {
+  font-family: var(--plk-font-body) !important;
+  font-size: 13px !important;
+}
+
+/* Subtle context for cursor when in placing mode */
+.mapboxgl-canvas-container.mapboxgl-interactive {
+  transition: cursor 0.1s ease;
+}
 
 @media only screen and (max-width: 720px) {
   .mapboxgl-ctrl-top-right {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,33 +1,130 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState, useRef } from "react";
 import "./App.css";
 import Navbar from "./Navbar";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppStore } from "../store/appStore";
 import searchMap from "../store/searchMap";
 import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles";
+import { type MapStyleId } from "../services/SearchMap";
+import MapStyleSwitcher from "./map/MapStyleSwitcher";
+import MapToolbar from "./map/MapToolbar";
+import MapContextMenu from "./map/MapContextMenu";
+import MapHUD from "./map/MapHUD";
+import MapLegend from "./map/MapLegend";
+import MapCrosshair from "./map/MapCrosshair";
 
 const profiles = new BehaviorProfiles();
+const DEFAULT_START = { lat: 37.775754, lng: -119.348739 };
 
 export default function App() {
   const setMapCenter = useAppStore((s) => s.setMapCenter);
+  const hasHydrated = useAppStore((s) => s.hasHydrated);
+  const persistedBehavior = useAppStore((s) => s.behavior);
+  const persistedMapStyle = useAppStore((s) => s.mapStyle);
+  const setPersistedMapStyle = useAppStore((s) => s.setMapStyle);
+  const ipp = useAppStore((s) => s.markers.byId.ipp);
+  const direction = useAppStore((s) => s.markers.byId.direction);
+  const legendOpen = useAppStore((s) => s.legendOpen);
+  const setLegendOpen = useAppStore((s) => s.setLegendOpen);
+
+  const [placingMode, setPlacingMode] = useState<null | "ipp" | "direction">(null);
+  const [activeStyle, setActiveStyle] = useState<MapStyleId>("outdoors");
+  const [cursor, setCursor] = useState<{ lng: number; lat: number } | null>(null);
+  const initialized = useRef(false);
 
   useEffect(() => {
-    const behavior = profiles.getClosestBehaviorByHierarchy([
-      "hiker",
-      "temperate",
-      "mtn",
-    ]);
-    const startPoint = { lat: 37.775754, lng: -119.348739 };
+    if (!hasHydrated || initialized.current) return;
+    initialized.current = true;
+
+    const initialHierarchy =
+      persistedBehavior?.hierarchy ?? ["hiker", "temperate", "mtn"];
+    const behavior = profiles.getClosestBehaviorByHierarchy(initialHierarchy);
+    const persistedIpp = ipp?.lngLat ?? null;
+    const persistedDirection = direction?.lngLat ?? null;
+    const startPoint = persistedIpp ?? DEFAULT_START;
+    const styleToUse = (persistedMapStyle as MapStyleId) ?? "outdoors";
+
     setMapCenter(startPoint);
+    searchMap.style = styleToUse;
+    setActiveStyle(styleToUse);
     searchMap.setBehavior(behavior);
-    searchMap.on("load", () => searchMap.setIPPMarker(startPoint));
+
+    searchMap.on("load", () => {
+      if (persistedIpp) {
+        searchMap.setIPPMarker(persistedIpp);
+      } else {
+        searchMap.setIPPMarker(startPoint);
+      }
+      if (persistedDirection) {
+        searchMap.setDestinationMarker(persistedDirection);
+      }
+    });
     searchMap.on("move", () => setMapCenter(searchMap.getLngLat()));
+    searchMap.on("placing.change", (mode: any) => setPlacingMode(mode));
+    searchMap.on("style.change", (s: MapStyleId) => {
+      setActiveStyle(s);
+      setPersistedMapStyle(s);
+    });
+    searchMap.on("mousemove", (evt: any) =>
+      setCursor({ lng: evt.lngLat.lng, lat: evt.lngLat.lat })
+    );
+
     searchMap.load("map", startPoint);
-  }, [setMapCenter]);
+  }, [hasHydrated]);
 
   const setBehaviorByKeys = useCallback((keys: string[]) => {
     const behavior = profiles.getClosestBehaviorByHierarchy(keys);
     searchMap.setBehavior(behavior);
+  }, []);
+
+  const handlePlaceIpp = useCallback(() => {
+    searchMap.setPlacingMode(placingMode === "ipp" ? null : "ipp");
+  }, [placingMode]);
+
+  const handlePlaceDirection = useCallback(() => {
+    searchMap.setPlacingMode(placingMode === "direction" ? null : "direction");
+  }, [placingMode]);
+
+  const handleClearAll = useCallback(() => {
+    searchMap.clearAll();
+  }, []);
+
+  const handleStyleChange = useCallback((id: MapStyleId) => {
+    searchMap.setMapStyle(id);
+  }, []);
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "SELECT" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const k = e.key.toLowerCase();
+      if (k === "i") {
+        e.preventDefault();
+        const center = searchMap.getLngLat();
+        if (center) searchMap.setIPPMarker(center);
+      } else if (k === "d") {
+        e.preventDefault();
+        const center = searchMap.getLngLat();
+        if (center) searchMap.setDestinationMarker(center);
+      } else if (k === "c") {
+        e.preventDefault();
+        searchMap.clearAll();
+      } else if (k === "escape") {
+        searchMap.setPlacingMode(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
   }, []);
 
   return (
@@ -36,6 +133,28 @@ export default function App() {
       <div className="app-content">
         <div className="map-container">
           <div id="map" />
+          <MapCrosshair visible={!placingMode} />
+          <MapStyleSwitcher active={activeStyle} onChange={handleStyleChange} />
+          <MapLegend
+            open={legendOpen}
+            onToggle={() => setLegendOpen(!legendOpen)}
+            hasIpp={!!ipp}
+            hasDirection={!!direction}
+          />
+          <MapToolbar
+            hasIpp={!!ipp}
+            hasDirection={!!direction}
+            placingMode={placingMode}
+            onPlaceIpp={handlePlaceIpp}
+            onPlaceDirection={handlePlaceDirection}
+            onClearAll={handleClearAll}
+          />
+          <MapHUD
+            ipp={ipp?.lngLat ?? null}
+            direction={direction?.lngLat ?? null}
+            cursor={cursor}
+          />
+          <MapContextMenu />
         </div>
       </div>
     </div>

--- a/src/components/map/MapContextMenu.tsx
+++ b/src/components/map/MapContextMenu.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useState, useRef } from "react";
+import { MapPin, Navigation, Crosshair, Copy, X } from "lucide-react";
+import searchMap from "../../store/searchMap";
+
+interface ContextMenuState {
+  point: { x: number; y: number };
+  lngLat: { lng: number; lat: number };
+}
+
+export default function MapContextMenu() {
+  const [menu, setMenu] = useState<ContextMenuState | null>(null);
+  const [copied, setCopied] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const handler = (evt: any) => {
+      if (!evt.originalEvent) return;
+      evt.originalEvent.preventDefault?.();
+      setMenu({
+        point: { x: evt.point.x, y: evt.point.y },
+        lngLat: { lng: evt.lngLat.lng, lat: evt.lngLat.lat },
+      });
+    };
+    const closeOnMove = () => setMenu(null);
+    const closeOnPlacingChange = () => setMenu(null);
+    searchMap.on("contextmenu", handler);
+    searchMap.on("move", closeOnMove);
+    searchMap.on("placing.change", closeOnPlacingChange);
+    return () => {
+      searchMap.off("contextmenu", handler);
+      searchMap.off("move", closeOnMove);
+      searchMap.off("placing.change", closeOnPlacingChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!menu) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setMenu(null);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenu(null);
+    };
+    window.addEventListener("mousedown", onDocClick);
+    window.addEventListener("keydown", onEsc);
+    return () => {
+      window.removeEventListener("mousedown", onDocClick);
+      window.removeEventListener("keydown", onEsc);
+    };
+  }, [menu]);
+
+  if (!menu) return null;
+
+  const items = [
+    {
+      icon: MapPin,
+      label: "Set IPP here",
+      action: () => {
+        searchMap.setIPPMarker(menu.lngLat);
+        setMenu(null);
+      },
+    },
+    {
+      icon: Navigation,
+      label: "Set Direction here",
+      action: () => {
+        searchMap.setDestinationMarker(menu.lngLat);
+        setMenu(null);
+      },
+    },
+    {
+      icon: Crosshair,
+      label: "Center map here",
+      action: () => {
+        searchMap.flyTo(menu.lngLat);
+        setMenu(null);
+      },
+    },
+    {
+      icon: Copy,
+      label: copied ? "Copied!" : "Copy coordinates",
+      action: async () => {
+        const text = `${menu.lngLat.lat.toFixed(6)}, ${menu.lngLat.lng.toFixed(6)}`;
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        } catch {
+          // ignore
+        }
+      },
+    },
+  ];
+
+  // Constrain to viewport
+  const left = Math.min(menu.point.x, window.innerWidth - 220);
+  const top = Math.min(menu.point.y, window.innerHeight - 220);
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-40 min-w-[200px] rounded-md bg-white p-1 shadow-[0_8px_24px_rgba(0,0,0,0.16),0_0_0_1px_rgba(26,24,22,0.16)]"
+      style={{ left, top }}
+    >
+      <div className="px-2.5 py-1.5 flex items-center justify-between gap-2 border-b border-rule mb-1">
+        <span className="font-mono text-[10px] tracking-[0.14em] uppercase text-warm-gray tabular-nums">
+          {menu.lngLat.lat.toFixed(5)}, {menu.lngLat.lng.toFixed(5)}
+        </span>
+        <button
+          onClick={() => setMenu(null)}
+          className="p-0.5 rounded-xs text-warm-gray hover:text-charcoal cursor-pointer"
+          aria-label="Close"
+        >
+          <X size={12} strokeWidth={1.75} />
+        </button>
+      </div>
+      {items.map(({ icon: Icon, label, action }) => (
+        <button
+          key={label}
+          onClick={action}
+          className="w-full flex items-center gap-2.5 rounded-sm px-2.5 py-2 font-mono text-[11px] uppercase tracking-[0.10em] text-charcoal hover:bg-snow transition-colors cursor-pointer text-left"
+        >
+          <Icon size={13} strokeWidth={1.75} />
+          <span>{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/map/MapCrosshair.tsx
+++ b/src/components/map/MapCrosshair.tsx
@@ -1,0 +1,16 @@
+interface MapCrosshairProps {
+  visible: boolean;
+}
+
+export default function MapCrosshair({ visible }: MapCrosshairProps) {
+  if (!visible) return null;
+  return (
+    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center">
+      <div className="relative w-7 h-7">
+        <span className="absolute inset-x-0 top-1/2 h-px bg-ink/70" />
+        <span className="absolute inset-y-0 left-1/2 w-px bg-ink/70" />
+        <span className="absolute inset-1.5 rounded-full border border-ink/70" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/map/MapHUD.tsx
+++ b/src/components/map/MapHUD.tsx
@@ -1,0 +1,71 @@
+import { getDistance, getRhumbLineBearing } from "geolib";
+import { Ruler, Compass } from "lucide-react";
+
+interface MapHUDProps {
+  ipp: { lng: number; lat: number } | null;
+  direction: { lng: number; lat: number } | null;
+  cursor: { lng: number; lat: number } | null;
+}
+
+function bearingToCardinal(deg: number): string {
+  const dirs = ["N", "NNE", "NE", "ENE", "E", "ESE", "SE", "SSE", "S", "SSW", "SW", "WSW", "W", "WNW", "NW", "NNW"];
+  const idx = Math.round(((deg % 360) / 22.5)) % 16;
+  return dirs[idx];
+}
+
+export default function MapHUD({ ipp, direction, cursor }: MapHUDProps) {
+  const showMeasurement = ipp && direction;
+
+  let distanceKm = 0;
+  let distanceMi = 0;
+  let bearingDeg = 0;
+  if (showMeasurement) {
+    const meters = getDistance(
+      { latitude: ipp!.lat, longitude: ipp!.lng },
+      { latitude: direction!.lat, longitude: direction!.lng }
+    );
+    distanceKm = meters / 1000;
+    distanceMi = meters / 1609.344;
+    bearingDeg = getRhumbLineBearing(
+      { latitude: ipp!.lat, longitude: ipp!.lng },
+      { latitude: direction!.lat, longitude: direction!.lng }
+    );
+  }
+
+  return (
+    <div className="absolute bottom-3 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2">
+      {showMeasurement && (
+        <div className="flex items-center gap-3 rounded-md bg-white/95 backdrop-blur px-3.5 py-2 shadow-[0_2px_8px_rgba(0,0,0,0.10),0_0_0_1px_rgba(26,24,22,0.16)]">
+          <div className="flex items-center gap-1.5">
+            <Ruler size={12} strokeWidth={1.75} className="text-warm-gray" />
+            <span className="font-mono text-[10px] tracking-[0.14em] uppercase text-warm-gray">Dist</span>
+            <span className="font-mono text-[12px] text-charcoal tabular-nums">
+              {distanceKm.toFixed(2)}
+              <span className="text-warm-gray">km</span>
+              <span className="text-warm-gray mx-1">·</span>
+              {distanceMi.toFixed(2)}
+              <span className="text-warm-gray">mi</span>
+            </span>
+          </div>
+          <div className="w-px h-4 bg-rule-strong" />
+          <div className="flex items-center gap-1.5">
+            <Compass size={12} strokeWidth={1.75} className="text-warm-gray" />
+            <span className="font-mono text-[10px] tracking-[0.14em] uppercase text-warm-gray">Brg</span>
+            <span className="font-mono text-[12px] text-charcoal tabular-nums">
+              {Math.round(bearingDeg)}°
+              <span className="text-warm-gray ml-1">{bearingToCardinal(bearingDeg)}</span>
+            </span>
+          </div>
+        </div>
+      )}
+      {cursor && (
+        <div className="hidden md:flex items-center gap-1.5 rounded-md bg-white/85 backdrop-blur px-2.5 py-1.5 shadow-[0_1px_4px_rgba(0,0,0,0.06),0_0_0_1px_rgba(26,24,22,0.10)]">
+          <span className="font-mono text-[9px] tracking-[0.14em] uppercase text-warm-gray">Cursor</span>
+          <span className="font-mono text-[11px] text-charcoal tabular-nums">
+            {cursor.lat.toFixed(4)}, {cursor.lng.toFixed(4)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/map/MapLegend.tsx
+++ b/src/components/map/MapLegend.tsx
@@ -1,0 +1,94 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+interface MapLegendProps {
+  open: boolean;
+  onToggle: () => void;
+  hasIpp: boolean;
+  hasDirection: boolean;
+}
+
+export default function MapLegend({ open, onToggle, hasIpp, hasDirection }: MapLegendProps) {
+  return (
+    <div className="absolute top-12 right-[calc(0.75rem+130px)] z-30 max-w-[260px]">
+      <div className="rounded-md bg-white/95 backdrop-blur shadow-[0_2px_8px_rgba(0,0,0,0.10),0_0_0_1px_rgba(26,24,22,0.16)]">
+        <button
+          onClick={onToggle}
+          className="w-full flex items-center justify-between gap-2 px-3 py-2 cursor-pointer hover:bg-snow rounded-md"
+          aria-expanded={open}
+        >
+          <span className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray">
+            Legend
+          </span>
+          {open ? (
+            <ChevronDown size={12} strokeWidth={1.75} className="text-warm-gray" />
+          ) : (
+            <ChevronRight size={12} strokeWidth={1.75} className="text-warm-gray" />
+          )}
+        </button>
+        {open && (
+          <div className="px-3 pb-3 space-y-2 border-t border-rule pt-2">
+            <LegendRow swatch={<Dot color="var(--plk-orange)" size={12} />} label="Initial Planning Point" muted={!hasIpp} />
+            <LegendRow swatch={<Dot color="var(--plk-charcoal)" size={9} />} label="Direction of Travel" muted={!hasDirection} />
+            <LegendRow swatch={<Ring color="var(--plk-orange)" />} label="Distance ring (25/50/75/95%)" muted={!hasIpp} />
+            <LegendRow swatch={<DashLine color="var(--plk-slate)" />} label="Dispersion fan" muted={!hasIpp || !hasDirection} />
+            <LegendRow swatch={<Line color="var(--plk-charcoal)" />} label="Direction of travel line" muted={!hasIpp || !hasDirection} />
+            <div className="pt-2 mt-1 border-t border-rule font-mono text-[9px] tracking-[0.10em] uppercase text-warm-gray leading-relaxed">
+              Right-click map for actions · I/D drops markers · C clears
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function LegendRow({
+  swatch,
+  label,
+  muted,
+}: {
+  swatch: React.ReactNode;
+  label: string;
+  muted?: boolean;
+}) {
+  return (
+    <div className={`flex items-center gap-2.5 ${muted ? "opacity-40" : ""}`}>
+      <div className="flex items-center justify-center w-5 shrink-0">{swatch}</div>
+      <span className="text-[11px] text-charcoal font-light leading-tight">{label}</span>
+    </div>
+  );
+}
+
+function Dot({ color, size }: { color: string; size: number }) {
+  return (
+    <span
+      className="inline-block rounded-full border-2 border-white shadow-[0_1px_2px_rgba(0,0,0,0.2)]"
+      style={{ background: color, width: size, height: size }}
+    />
+  );
+}
+
+function Ring({ color }: { color: string }) {
+  return (
+    <span
+      className="inline-block rounded-full border-2"
+      style={{ borderColor: color, width: 14, height: 14, opacity: 0.7 }}
+    />
+  );
+}
+
+function Line({ color }: { color: string }) {
+  return <span className="inline-block w-4 h-0.5" style={{ background: color }} />;
+}
+
+function DashLine({ color }: { color: string }) {
+  return (
+    <span
+      className="inline-block w-4 h-0.5"
+      style={{
+        backgroundImage: `repeating-linear-gradient(to right, ${color} 0 3px, transparent 3px 6px)`,
+        height: 2,
+      }}
+    />
+  );
+}

--- a/src/components/map/MapStyleSwitcher.tsx
+++ b/src/components/map/MapStyleSwitcher.tsx
@@ -1,0 +1,42 @@
+import { Mountain, Satellite, Map as MapIcon, Moon } from "lucide-react";
+import { MAP_STYLES, type MapStyleId } from "../../services/SearchMap";
+
+const styleIcons: Record<MapStyleId, typeof Mountain> = {
+  outdoors: Mountain,
+  satellite: Satellite,
+  streets: MapIcon,
+  dark: Moon,
+};
+
+interface MapStyleSwitcherProps {
+  active: MapStyleId;
+  onChange: (id: MapStyleId) => void;
+}
+
+export default function MapStyleSwitcher({ active, onChange }: MapStyleSwitcherProps) {
+  return (
+    <div className="absolute top-12 right-3 z-30 flex flex-col gap-1 rounded-md bg-white/95 backdrop-blur p-1 shadow-[0_2px_8px_rgba(0,0,0,0.10),0_0_0_1px_rgba(26,24,22,0.16)]">
+      {(Object.keys(MAP_STYLES) as MapStyleId[]).map((id) => {
+        const style = MAP_STYLES[id];
+        const Icon = styleIcons[id];
+        const isActive = id === active;
+        return (
+          <button
+            key={id}
+            onClick={() => onChange(id)}
+            title={style.label}
+            aria-label={`Switch to ${style.label} basemap`}
+            className={`flex items-center gap-2 rounded-sm px-2.5 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors cursor-pointer ${
+              isActive
+                ? "bg-ink text-white"
+                : "bg-transparent text-charcoal hover:bg-snow"
+            }`}
+          >
+            <Icon size={13} strokeWidth={1.75} />
+            <span>{style.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/map/MapToolbar.tsx
+++ b/src/components/map/MapToolbar.tsx
@@ -1,0 +1,73 @@
+import { MapPin, Navigation, Eraser } from "lucide-react";
+
+interface MapToolbarProps {
+  hasIpp: boolean;
+  hasDirection: boolean;
+  placingMode: null | "ipp" | "direction";
+  onPlaceIpp: () => void;
+  onPlaceDirection: () => void;
+  onClearAll: () => void;
+}
+
+export default function MapToolbar({
+  hasIpp,
+  hasDirection,
+  placingMode,
+  onPlaceIpp,
+  onPlaceDirection,
+  onClearAll,
+}: MapToolbarProps) {
+  const btnBase =
+    "group flex items-center gap-2 rounded-sm px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors cursor-pointer border";
+  const idle =
+    "bg-white text-charcoal border-rule-strong hover:border-charcoal hover:bg-snow";
+  const active = "bg-ink text-white border-ink";
+  const danger =
+    "bg-white text-orange-brand border-rule-strong hover:bg-orange-tint hover:border-orange-brand";
+
+  return (
+    <div className="absolute bottom-3 left-3 z-30 flex flex-col gap-1 rounded-md bg-white/95 backdrop-blur p-1.5 shadow-[0_2px_8px_rgba(0,0,0,0.10),0_0_0_1px_rgba(26,24,22,0.16)]">
+      <button
+        onClick={onPlaceIpp}
+        className={`${btnBase} ${placingMode === "ipp" ? active : idle}`}
+        title="Click on map to place Initial Planning Point (I)"
+      >
+        <MapPin size={13} strokeWidth={1.75} />
+        <span>{placingMode === "ipp" ? "Click map…" : hasIpp ? "Move IPP" : "Drop IPP"}</span>
+        <kbd className="ml-1 px-1 py-px rounded-xs bg-silver-light text-warm-gray text-[9px] tracking-normal group-hover:bg-white">
+          I
+        </kbd>
+      </button>
+      <button
+        onClick={onPlaceDirection}
+        className={`${btnBase} ${placingMode === "direction" ? active : idle}`}
+        title="Click on map to place Direction of Travel (D)"
+      >
+        <Navigation size={13} strokeWidth={1.75} />
+        <span>
+          {placingMode === "direction"
+            ? "Click map…"
+            : hasDirection
+              ? "Move Direction"
+              : "Drop Direction"}
+        </span>
+        <kbd className="ml-1 px-1 py-px rounded-xs bg-silver-light text-warm-gray text-[9px] tracking-normal group-hover:bg-white">
+          D
+        </kbd>
+      </button>
+      {(hasIpp || hasDirection) && (
+        <button
+          onClick={onClearAll}
+          className={`${btnBase} ${danger}`}
+          title="Clear all markers (C)"
+        >
+          <Eraser size={13} strokeWidth={1.75} />
+          <span>Clear</span>
+          <kbd className="ml-1 px-1 py-px rounded-xs bg-orange-tint text-orange-brand text-[9px] tracking-normal">
+            C
+          </kbd>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -8,49 +8,122 @@ import StatisticsVirtualLayer from './statistics/StatisticsVirtualLayer';
 import EventEmitter from 'events';
 import { useAppStore } from '../store/appStore';
 
+export const MAP_STYLES = {
+  outdoors: { id: 'outdoors', label: 'Topo', url: 'mapbox://styles/mapbox/outdoors-v11' },
+  satellite: { id: 'satellite', label: 'Satellite', url: 'mapbox://styles/mapbox/satellite-streets-v12' },
+  streets: { id: 'streets', label: 'Streets', url: 'mapbox://styles/mapbox/streets-v12' },
+  dark: { id: 'dark', label: 'Dark', url: 'mapbox://styles/mapbox/dark-v11' }
+} as const;
+
+export type MapStyleId = keyof typeof MAP_STYLES;
+
 export default class SearchMap extends EventEmitter {
   constructor() {
     super();
+    this.setMaxListeners(50);
     this.map = null;
     this.statsLayer = new StatisticsVirtualLayer();
     this.markers = {
       ipp: null,
       destination: null
-    }
+    };
+    this.style = 'outdoors';
+    this.placingMode = null; // null | 'ipp' | 'direction'
   }
   load(containerId, lngLat) {
     this.map = new mapboxgl.Map({
       container: containerId,
-      style: 'mapbox://styles/mapbox/outdoors-v11',
+      style: MAP_STYLES[this.style].url,
       center: new LngLat(lngLat).toJSON(),
       zoom: 10
     });
-    this.map.addControl(new mapboxgl.NavigationControl(), 'top-left');
-    this.map.addControl(new MapboxGeocoder({
-      accessToken: mapboxgl.accessToken,
-      mapboxgl: mapboxgl
-    }));
-    this.map.on('load', data => this.emit('load', data));
-    this.map.on('move', data => this.emit('move', data))
+    this.map.addControl(new mapboxgl.NavigationControl({ visualizePitch: true }), 'top-left');
+    this.map.addControl(
+      new mapboxgl.GeolocateControl({
+        positionOptions: { enableHighAccuracy: true },
+        trackUserLocation: false,
+        showAccuracyCircle: true
+      }),
+      'top-left'
+    );
+    this.map.addControl(new mapboxgl.FullscreenControl(), 'top-left');
+    this.map.addControl(new mapboxgl.ScaleControl({ unit: 'imperial' }), 'bottom-right');
+    this.map.addControl(
+      new MapboxGeocoder({
+        accessToken: mapboxgl.accessToken,
+        mapboxgl: mapboxgl,
+        collapsed: true,
+        placeholder: 'Search location'
+      })
+    );
+
+    this.map.on('load', (data) => this.emit('load', data));
+    this.map.on('move', (data) => this.emit('move', data));
+    this.map.on('mousemove', (evt) => this.emit('mousemove', evt));
+    this.map.on('contextmenu', (evt) => {
+      this.emit('contextmenu', evt);
+    });
+    this.map.on('click', (evt) => {
+      if (this.placingMode === 'ipp') {
+        this.setIPPMarker(evt.lngLat);
+        this.setPlacingMode(null);
+      } else if (this.placingMode === 'direction') {
+        this.setDestinationMarker(evt.lngLat);
+        this.setPlacingMode(null);
+      }
+      this.emit('click', evt);
+    });
+    this.map.on('style.load', () => {
+      // After a style switch, custom sources/layers are wiped.
+      // Reset references and redraw whatever was active.
+      this.statsLayer.markStyleReset();
+      if (this.markers.ipp) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
+      if (this.markers.ipp && this.markers.destination)
+        this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+      this.emit('style.load', this.style);
+    });
     this.statsLayer.addTo(this.map);
   }
   resize() {
-    if(this.map) this.map.resize();
+    if (this.map) this.map.resize();
   }
-  setIPPMarker = lngLat => {
+  setMapStyle = (styleKey: MapStyleId) => {
+    if (!this.map || !MAP_STYLES[styleKey]) return;
+    // Clear current style-bound layers before switching
+    this.statsLayer.clearRings();
+    this.statsLayer.clearDispersion();
+    this.style = styleKey;
+    this.map.setStyle(MAP_STYLES[styleKey].url);
+    this.emit('style.change', styleKey);
+  };
+  getMapStyle() {
+    return this.style;
+  }
+  setPlacingMode = (mode: null | 'ipp' | 'direction') => {
+    this.placingMode = mode;
+    if (this.map) {
+      const canvas = this.map.getCanvas();
+      canvas.style.cursor = mode ? 'crosshair' : '';
+    }
+    this.emit('placing.change', mode);
+  };
+  getPlacingMode() {
+    return this.placingMode;
+  }
+  setIPPMarker = (lngLat) => {
     lngLat = new LngLat(lngLat);
     const { setIppMarker } = useAppStore.getState();
     const updateStore = () => {
       setIppMarker([{ _id: 'ipp', lngLat: this.markers.ipp.getLngLat() }]);
     };
-    if(this.markers.ipp) {
+    if (this.markers.ipp) {
       this.markers.ipp.setLngLat(lngLat.toJSON());
     } else {
       this.markers.ipp = new InitialPlanningMarker({
         id: 'ipp',
         className: 'ipp-marker',
         draggable: true
-      })
+      });
       this.markers.ipp.setLngLat(lngLat.toJSON());
       this.markers.ipp.addTo(this.map);
       this.markers.ipp.on('dragstart', () => {
@@ -60,37 +133,40 @@ export default class SearchMap extends EventEmitter {
       });
       this.markers.ipp.on('drag', () => {
         updateStore();
-      })
+      });
       this.markers.ipp.on('dragend', () => {
         this.statsLayer.drawRings(this.markers.ipp, this.behavior);
-        if(this.markers.destination) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+        if (this.markers.destination)
+          this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
         updateStore();
       });
     }
     this.statsLayer.drawRings(this.markers.ipp, this.behavior);
-    if(this.markers.destination) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+    if (this.markers.destination)
+      this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
     updateStore();
-  }
+  };
   clearIPPMarker = () => {
-    if(this.markers.ipp) this.markers.ipp.remove();
+    if (this.markers.ipp) this.markers.ipp.remove();
     this.markers.ipp = null;
     this.statsLayer.clearRings();
     this.statsLayer.clearDispersion();
     useAppStore.getState().clearIppMarker();
-  }
-  flyTo = lngLat => {
+  };
+  flyTo = (lngLat) => {
     lngLat = new LngLat(lngLat);
+    if (!this.map) return;
     this.map.flyTo({
       center: lngLat.toJSON()
     });
     useAppStore.getState().setMapCenter(lngLat.toJSON());
-  }
+  };
   getLngLat() {
-    if(this.map) return this.map.getCenter();
+    if (this.map) return this.map.getCenter();
   }
-  setDestinationMarker(lngLat) {
+  setDestinationMarker = (lngLat) => {
     lngLat = new LngLat(lngLat);
-    if(this.markers.destination) {
+    if (this.markers.destination) {
       this.markers.destination.setLngLat(lngLat.toJSON());
     } else {
       this.markers.destination = new DestinationMarker({
@@ -103,26 +179,42 @@ export default class SearchMap extends EventEmitter {
       this.markers.destination.on('dragstart', () => {
         this.statsLayer.clearDispersion();
       });
-      this.markers.destination.on('dragend', (evt) => {
-        if(this.markers.ipp) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
-        useAppStore.getState().setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
+      this.markers.destination.on('drag', () => {
+        useAppStore
+          .getState()
+          .setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
+      });
+      this.markers.destination.on('dragend', () => {
+        if (this.markers.ipp)
+          this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+        useAppStore
+          .getState()
+          .setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
       });
     }
-    useAppStore.getState().setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
-    if(this.markers.ipp) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
-  }
-  clearDestinationMarker() {
-    if(this.markers.destination) {
+    useAppStore
+      .getState()
+      .setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
+    if (this.markers.ipp)
+      this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+  };
+  clearDestinationMarker = () => {
+    if (this.markers.destination) {
       this.markers.destination.remove();
     }
     this.markers.destination = null;
     this.statsLayer.clearDispersion();
     useAppStore.getState().clearDirectionMarker();
-  }
+  };
+  clearAll = () => {
+    this.clearIPPMarker();
+    this.clearDestinationMarker();
+  };
   setBehavior(behavior) {
     this.behavior = behavior;
     useAppStore.getState().setBehavior(behavior.toJSON());
-    if(this.markers.ipp && this.markers.destination) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
-    if(this.markers.ipp) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
+    if (this.markers.ipp && this.markers.destination)
+      this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+    if (this.markers.ipp) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
   }
 }

--- a/src/services/statistics/StatisticsVirtualLayer.ts
+++ b/src/services/statistics/StatisticsVirtualLayer.ts
@@ -18,6 +18,16 @@ export default class StatisticsVirtualLayer {
   addTo(map) {
     this.map = map;
   }
+  markStyleReset() {
+    // Custom layers/sources are wiped when the basemap style changes.
+    // Drop our references so we don't try to remove non-existent layers.
+    this.layers = {
+      rings: null,
+      labels: null,
+      dispersionLines: null,
+      directionLine: null
+    };
+  }
   clearRings() {
     if(!this.map) return null;
     if(this.layers.rings) {

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { initializeNormalState, mergeItems, removeItem } from '../utils/normalize'
 
 interface MarkerState {
@@ -10,6 +11,9 @@ interface AppState {
   markers: MarkerState
   behavior: any | null
   mapCenter: any | null
+  mapStyle: string
+  legendOpen: boolean
+  hasHydrated: boolean
 
   // Marker actions
   setIppMarker: (items: any[]) => void
@@ -22,26 +26,63 @@ interface AppState {
 
   // Map actions
   setMapCenter: (lngLat: any) => void
+  setMapStyle: (style: string) => void
+
+  // UI actions
+  setLegendOpen: (open: boolean) => void
+  setHasHydrated: (v: boolean) => void
 }
 
-export const useAppStore = create<AppState>((set) => ({
-  markers: initializeNormalState(),
-  behavior: null,
-  mapCenter: null,
+export const useAppStore = create<AppState>()(
+  persist(
+    (set) => ({
+      markers: initializeNormalState(),
+      behavior: null,
+      mapCenter: null,
+      mapStyle: 'outdoors',
+      legendOpen: true,
+      hasHydrated: false,
 
-  setIppMarker: (items) =>
-    set((state) => ({ markers: mergeItems(state.markers, items) })),
+      setIppMarker: (items) =>
+        set((state) => ({ markers: mergeItems(state.markers, items) })),
 
-  clearIppMarker: () =>
-    set((state) => ({ markers: removeItem(state.markers, 'ipp') })),
+      clearIppMarker: () =>
+        set((state) => ({ markers: removeItem(state.markers, 'ipp') })),
 
-  setDirectionMarker: (items) =>
-    set((state) => ({ markers: mergeItems(state.markers, items) })),
+      setDirectionMarker: (items) =>
+        set((state) => ({ markers: mergeItems(state.markers, items) })),
 
-  clearDirectionMarker: () =>
-    set((state) => ({ markers: removeItem(state.markers, 'direction') })),
+      clearDirectionMarker: () =>
+        set((state) => ({ markers: removeItem(state.markers, 'direction') })),
 
-  setBehavior: (behavior) => set({ behavior }),
+      setBehavior: (behavior) => set({ behavior }),
 
-  setMapCenter: (lngLat) => set({ mapCenter: lngLat }),
-}))
+      setMapCenter: (lngLat) => set({ mapCenter: lngLat }),
+      setMapStyle: (mapStyle) => set({ mapStyle }),
+
+      setLegendOpen: (legendOpen) => set({ legendOpen }),
+      setHasHydrated: (hasHydrated) => set({ hasHydrated }),
+    }),
+    {
+      name: 'sarmapper-state',
+      storage: createJSONStorage(() =>
+        typeof window !== 'undefined'
+          ? window.localStorage
+          : ({
+              getItem: () => null,
+              setItem: () => {},
+              removeItem: () => {},
+            } as Storage)
+      ),
+      partialize: (state) => ({
+        markers: state.markers,
+        behavior: state.behavior,
+        mapStyle: state.mapStyle,
+        legendOpen: state.legendOpen,
+      }),
+      onRehydrateStorage: () => (state) => {
+        state?.setHasHydrated(true)
+      },
+    }
+  )
+)


### PR DESCRIPTION
## Summary
This PR significantly enhances the map interface with new controls, basemap style switching, interactive marker placement modes, and a comprehensive UI layer including context menus, toolbars, and HUD displays.

## Key Changes

### Map Service Enhancements (`SearchMap.ts`)
- Added `MAP_STYLES` constant with four basemap options (Outdoors, Satellite, Streets, Dark) with TypeScript type safety
- Implemented map style switching with `setMapStyle()` method that properly handles layer cleanup and restoration
- Added `placingMode` state management to support interactive marker placement (IPP or Direction)
- Introduced `setPlacingMode()` to toggle placement modes with visual cursor feedback (crosshair)
- Enhanced map controls: added Geolocate, Fullscreen, and Scale controls with improved Navigation control
- Added event handlers for `mousemove`, `contextmenu`, and `click` with placement mode logic
- Implemented `style.load` handler to restore custom layers/rings after basemap style changes
- Added `clearAll()` convenience method to clear both markers at once
- Improved code formatting and consistency (spacing, arrow functions)

### State Management (`appStore.ts`)
- Integrated Zustand persistence middleware with localStorage
- Added `mapStyle`, `legendOpen`, and `hasHydrated` state properties
- Implemented selective persistence (markers, behavior, mapStyle, legendOpen)
- Added `setMapStyle()` and `setLegendOpen()` actions
- Added `setHasHydrated()` for hydration lifecycle management

### New UI Components
- **`MapStyleSwitcher.tsx`**: Compact button group for switching between four basemap styles with icons
- **`MapToolbar.tsx`**: Bottom-left toolbar with IPP/Direction placement buttons and clear action, includes keyboard shortcuts (I/D/C)
- **`MapContextMenu.tsx`**: Right-click context menu with options to place markers, center map, and copy coordinates
- **`MapHUD.tsx`**: Bottom-center display showing distance (km/mi) and bearing (degrees/cardinal) between IPP and Direction markers, plus cursor coordinates
- **`MapLegend.tsx`**: Collapsible legend showing marker types, rings, dispersion fan, and keyboard shortcuts

### App Integration (`App.tsx`)
- Refactored initialization to use persisted state (behavior, map style, markers)
- Added event listeners for map style changes, placing mode changes, and mouse movement
- Implemented keyboard shortcuts: I (place IPP), D (place Direction), C (clear all), Escape (cancel placing)
- Integrated all new map UI components
- Added proper hydration handling for localStorage restoration

### Statistics Layer (`StatisticsVirtualLayer.ts`)
- Added `markStyleReset()` method to clear layer references when basemap style changes, preventing errors from trying to remove non-existent layers

### Styling (`App.css`)
- Added styles for Mapbox scale control with backdrop blur and custom typography
- Enhanced geocoder styling for collapsed state
- Added smooth cursor transitions for interactive states

## Notable Implementation Details
- Map style switching properly cleans up custom layers before switching and restores them after the new style loads
- Placing mode provides visual feedback via cursor changes (crosshair) and button state
- Context menu constrains itself to viewport to prevent overflow
- All new components use Lucide React icons for consistency
- Keyboard shortcuts respect input elements and modifier keys
- State persistence enables users to resume their work across sessions

https://claude.ai/code/session_017AXb2CmDj2eTiQfvMLPnGe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new map event flows (style switching, click-based placing modes, context menu) and persists additional UI/map state to `localStorage`, which could impact initialization/hydration and Mapbox layer re-rendering if edge cases are missed.
> 
> **Overview**
> Upgrades the map experience with **basemap style switching**, additional Mapbox controls (geolocate/fullscreen/scale, collapsed geocoder), and a new **placing mode** that drops IPP/direction markers via map clicks and updates cursor feedback.
> 
> Adds an on-map UI layer: `MapToolbar` (place/clear actions + shortcuts), `MapContextMenu` (right-click actions + copy coords), `MapHUD` (distance/bearing + cursor readout), `MapLegend` (collapsible symbology/shortcuts), `MapStyleSwitcher`, and `MapCrosshair`.
> 
> Introduces Zustand persistence for markers/behavior/map style/legend state with hydration gating in `App.tsx`, and updates `SearchMap`/`StatisticsVirtualLayer` to handle style reloads by clearing/resetting custom layer references and redrawing overlays after a style change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32041122fd0c3c802eb5cedc1fe6dbe4d2a11ce1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->