### PR TITLE
Add map style switcher component

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useCallback } from "react";
 import "./App.css";
 import Navbar from "./Navbar";
+import MapSwitcher from "./MapSwitcher";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppStore } from "../store/appStore";
 import searchMap from "../store/searchMap";
@@ -36,6 +37,7 @@ export default function App() {
       <div className="app-content">
         <div className="map-container">
           <div id="map" />
+          <MapSwitcher />
         </div>
       </div>
     </div>

--- a/src/components/MapSwitcher.tsx
+++ b/src/components/MapSwitcher.tsx
@@ -1,23 +1,15 @@
 import { useState, useRef, useEffect } from "react";
 import { Layers } from "lucide-react";
 import searchMap from "../store/searchMap";
-
-const STYLES = [
-  { id: "topo", label: "Topo", url: "mapbox://styles/mapbox/outdoors-v12" },
-  {
-    id: "satellite",
-    label: "Satellite",
-    url: "mapbox://styles/mapbox/satellite-streets-v12",
-  },
-  { id: "streets", label: "Streets", url: "mapbox://styles/mapbox/streets-v12" },
-  { id: "dark", label: "Dark", url: "mapbox://styles/mapbox/dark-v11" },
-] as const;
-
-type StyleId = (typeof STYLES)[number]["id"];
+import {
+  MAP_STYLES,
+  DEFAULT_MAP_STYLE,
+  type MapStyleId,
+} from "../services/map/mapStyles";
 
 export default function MapSwitcher() {
   const [open, setOpen] = useState(false);
-  const [activeId, setActiveId] = useState<StyleId>("topo");
+  const [activeId, setActiveId] = useState<MapStyleId>(DEFAULT_MAP_STYLE.id);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -30,7 +22,7 @@ export default function MapSwitcher() {
     return () => window.removeEventListener("mousedown", onClick);
   }, [open]);
 
-  const select = (id: StyleId, url: string) => {
+  const select = (id: MapStyleId, url: string) => {
     setActiveId(id);
     searchMap.setMapStyle(url);
     setOpen(false);
@@ -39,11 +31,19 @@ export default function MapSwitcher() {
   return (
     <div
       ref={ref}
-      className="absolute bottom-3 right-3 z-10 flex flex-col items-end"
+      className="absolute top-[110px] left-[10px] z-10 flex flex-col items-start"
     >
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Map style"
+        aria-expanded={open}
+        className="flex items-center justify-center h-[29px] w-[29px] bg-white rounded-lg shadow-[0_1px_4px_rgba(0,0,0,0.06),0_0_0_1px_var(--plk-rule-strong)] text-charcoal hover:bg-snow cursor-pointer transition-colors"
+      >
+        <Layers size={14} strokeWidth={1.75} />
+      </button>
       {open && (
-        <div className="mb-1 bg-white border border-rule-strong rounded-sm shadow-[0_2px_8px_rgba(0,0,0,0.08)] overflow-hidden">
-          {STYLES.map((s) => (
+        <div className="mt-1 bg-white rounded-lg shadow-[0_1px_4px_rgba(0,0,0,0.06),0_0_0_1px_var(--plk-rule-strong)] overflow-hidden">
+          {MAP_STYLES.map((s) => (
             <button
               key={s.id}
               onClick={() => select(s.id, s.url)}
@@ -58,14 +58,6 @@ export default function MapSwitcher() {
           ))}
         </div>
       )}
-      <button
-        onClick={() => setOpen((v) => !v)}
-        aria-label="Map style"
-        aria-expanded={open}
-        className="flex items-center justify-center h-8 w-8 bg-white/95 backdrop-blur-sm border border-rule-strong rounded-sm shadow-[0_2px_8px_rgba(0,0,0,0.08)] text-charcoal hover:bg-white cursor-pointer transition-colors"
-      >
-        <Layers size={14} strokeWidth={1.75} />
-      </button>
     </div>
   );
 }

--- a/src/components/MapSwitcher.tsx
+++ b/src/components/MapSwitcher.tsx
@@ -1,0 +1,71 @@
+import { useState, useRef, useEffect } from "react";
+import { Layers } from "lucide-react";
+import searchMap from "../store/searchMap";
+
+const STYLES = [
+  { id: "topo", label: "Topo", url: "mapbox://styles/mapbox/outdoors-v12" },
+  {
+    id: "satellite",
+    label: "Satellite",
+    url: "mapbox://styles/mapbox/satellite-streets-v12",
+  },
+  { id: "streets", label: "Streets", url: "mapbox://styles/mapbox/streets-v12" },
+  { id: "dark", label: "Dark", url: "mapbox://styles/mapbox/dark-v11" },
+] as const;
+
+type StyleId = (typeof STYLES)[number]["id"];
+
+export default function MapSwitcher() {
+  const [open, setOpen] = useState(false);
+  const [activeId, setActiveId] = useState<StyleId>("topo");
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
+    };
+    window.addEventListener("mousedown", onClick);
+    return () => window.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const select = (id: StyleId, url: string) => {
+    setActiveId(id);
+    searchMap.setMapStyle(url);
+    setOpen(false);
+  };
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-3 right-3 z-10 flex flex-col items-end"
+    >
+      {open && (
+        <div className="mb-1 bg-white border border-rule-strong rounded-sm shadow-[0_2px_8px_rgba(0,0,0,0.08)] overflow-hidden">
+          {STYLES.map((s) => (
+            <button
+              key={s.id}
+              onClick={() => select(s.id, s.url)}
+              className={`block w-full text-left px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] transition-colors cursor-pointer ${
+                activeId === s.id
+                  ? "bg-ink text-white"
+                  : "bg-white text-charcoal hover:bg-snow"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      )}
+      <button
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Map style"
+        aria-expanded={open}
+        className="flex items-center justify-center h-8 w-8 bg-white/95 backdrop-blur-sm border border-rule-strong rounded-sm shadow-[0_2px_8px_rgba(0,0,0,0.08)] text-charcoal hover:bg-white cursor-pointer transition-colors"
+      >
+        <Layers size={14} strokeWidth={1.75} />
+      </button>
+    </div>
+  );
+}

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -7,6 +7,7 @@ import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css';
 import StatisticsVirtualLayer from './statistics/StatisticsVirtualLayer';
 import EventEmitter from 'events';
 import { useAppStore } from '../store/appStore';
+import { DEFAULT_MAP_STYLE } from './map/mapStyles';
 
 export default class SearchMap extends EventEmitter {
   constructor() {
@@ -21,7 +22,7 @@ export default class SearchMap extends EventEmitter {
   load(containerId, lngLat) {
     this.map = new mapboxgl.Map({
       container: containerId,
-      style: 'mapbox://styles/mapbox/outdoors-v11',
+      style: DEFAULT_MAP_STYLE.url,
       center: new LngLat(lngLat).toJSON(),
       zoom: 10
     });

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -125,4 +125,14 @@ export default class SearchMap extends EventEmitter {
     if(this.markers.ipp && this.markers.destination) this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
     if(this.markers.ipp) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
   }
+  setMapStyle = (styleUrl) => {
+    if(!this.map) return;
+    this.map.once('style.load', () => {
+      if(this.markers.ipp && this.behavior) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
+      if(this.markers.ipp && this.markers.destination && this.behavior) {
+        this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
+      }
+    });
+    this.map.setStyle(styleUrl);
+  }
 }

--- a/src/services/map/MapStyleLayer.ts
+++ b/src/services/map/MapStyleLayer.ts
@@ -12,8 +12,9 @@ export default class MapStyleLayer {
     this.map.addLayer(Object.assign({}, this.layer));
   }
   remove = () => {
-    this.map.removeLayer(this.id);
-    this.map.removeSource(this.id);
+    if(!this.map) return;
+    if(this.map.getLayer(this.id)) this.map.removeLayer(this.id);
+    if(this.map.getSource(this.id)) this.map.removeSource(this.id);
   }
   toJSON() {
     return Object.assign({}, this.layer);

--- a/src/services/map/mapStyles.ts
+++ b/src/services/map/mapStyles.ts
@@ -1,0 +1,14 @@
+export const MAP_STYLES = [
+  { id: "topo", label: "Topo", url: "mapbox://styles/mapbox/outdoors-v12" },
+  {
+    id: "satellite",
+    label: "Satellite",
+    url: "mapbox://styles/mapbox/satellite-streets-v12",
+  },
+  { id: "streets", label: "Streets", url: "mapbox://styles/mapbox/streets-v12" },
+  { id: "dark", label: "Dark", url: "mapbox://styles/mapbox/dark-v11" },
+] as const;
+
+export const DEFAULT_MAP_STYLE = MAP_STYLES[0];
+
+export type MapStyleId = (typeof MAP_STYLES)[number]["id"];


### PR DESCRIPTION
## Summary
This PR adds a map style switcher UI component that allows users to toggle between different Mapbox map styles (Topo, Satellite, Streets, and Dark).

## Key Changes
- **New MapSwitcher component** (`src/components/MapSwitcher.tsx`): A dropdown button that displays four map style options. Features include:
  - Toggle dropdown menu with click-outside detection
  - Active style indicator with visual feedback
  - Smooth transitions and accessibility attributes (aria-label, aria-expanded)
  - Positioned in the bottom-right corner of the map

- **SearchMap service enhancement** (`src/services/SearchMap.ts`):
  - Added `setMapStyle()` method to change the map style via Mapbox API
  - Redraw statistical layers (rings and dispersion) after style change to ensure they persist across style switches

- **MapStyleLayer robustness** (`src/services/map/MapStyleLayer.ts`):
  - Added null checks in `remove()` method to safely handle layer/source removal
  - Prevents errors when layers or sources don't exist before removal

- **App integration** (`src/components/App.tsx`):
  - Imported and rendered MapSwitcher component in the map container

## Implementation Details
- Uses React hooks (useState, useRef, useEffect) for state management and click-outside detection
- Leverages Lucide React's Layers icon for the UI button
- Integrates with existing Zustand store (`searchMap`) for map state management
- Maintains active style state locally in the component
- Listens to Mapbox's 'style.load' event to redraw overlays after style changes

https://claude.ai/code/session_01UE3cw7PnLATyYAvyJJpeNN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces runtime Mapbox style switching and re-renders custom overlay layers after `style.load`, which can affect map rendering/state if events fire unexpectedly. No auth or data-handling logic is changed.
> 
> **Overview**
> Adds a new in-map `MapSwitcher` control that lets users toggle between multiple Mapbox base styles and wires it into `App`.
> 
> Extends `SearchMap` with `setMapStyle()` to call `map.setStyle()` and re-draw rings/dispersion overlays after a style reload, and hardens `MapStyleLayer.remove()` with existence checks to avoid errors when layers/sources are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5022183f0e5666950d02ce0cee105e4e0c4d66b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->