### PR TITLE
Add map legend and context menu for marker placement

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
 import "./App.css";
 import Navbar from "./Navbar";
 import MapSwitcher from "./MapSwitcher";
+import Legend from "./Legend";
+import MapContextMenu from "./MapContextMenu";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppStore } from "../store/appStore";
 import searchMap from "../store/searchMap";
@@ -9,8 +11,17 @@ import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles
 
 const profiles = new BehaviorProfiles();
 
+interface ContextMenuState {
+  x: number;
+  y: number;
+  lngLat: { lng: number; lat: number };
+}
+
 export default function App() {
   const setMapCenter = useAppStore((s) => s.setMapCenter);
+  const ipp = useAppStore((s) => s.markers.byId.ipp);
+  const direction = useAppStore((s) => s.markers.byId.direction);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
 
   useEffect(() => {
     const behavior = profiles.getClosestBehaviorByHierarchy([
@@ -26,6 +37,20 @@ export default function App() {
     searchMap.load("map", startPoint);
   }, [setMapCenter]);
 
+  useEffect(() => {
+    const handler = (evt: any) => {
+      setContextMenu({
+        x: evt.point.x,
+        y: evt.point.y,
+        lngLat: { lng: evt.lngLat.lng, lat: evt.lngLat.lat },
+      });
+    };
+    searchMap.on("contextmenu", handler);
+    return () => {
+      searchMap.off("contextmenu", handler);
+    };
+  }, []);
+
   const setBehaviorByKeys = useCallback((keys: string[]) => {
     const behavior = profiles.getClosestBehaviorByHierarchy(keys);
     searchMap.setBehavior(behavior);
@@ -35,9 +60,26 @@ export default function App() {
     <div className="app">
       <Navbar setBehaviorByKeys={setBehaviorByKeys} />
       <div className="app-content">
-        <div className="map-container">
+        <div
+          className="map-container"
+          onContextMenu={(e) => e.preventDefault()}
+        >
           <div id="map" />
           <MapSwitcher />
+          <Legend />
+          {contextMenu && (
+            <MapContextMenu
+              x={contextMenu.x}
+              y={contextMenu.y}
+              hasIpp={Boolean(ipp)}
+              hasDirection={Boolean(direction)}
+              onPlaceIpp={() => searchMap.setIPPMarker(contextMenu.lngLat)}
+              onPlaceDirection={() =>
+                searchMap.setDestinationMarker(contextMenu.lngLat)
+              }
+              onClose={() => setContextMenu(null)}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { Info, X } from "lucide-react";
+
+const MOBILE_QUERY = "(max-width: 720px)";
+
+export default function Legend() {
+  const [open, setOpen] = useState(true);
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(MOBILE_QUERY);
+    const update = () => {
+      setIsMobile(mql.matches);
+      setOpen(!mql.matches);
+    };
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+
+  return (
+    <div className="absolute bottom-7 right-2 z-10 flex flex-col items-end">
+      {open ? (
+        <div className="bg-white rounded-lg shadow-[0_1px_4px_rgba(0,0,0,0.06),0_0_0_1px_var(--plk-rule-strong)] p-3 w-[220px]">
+          <div className="flex items-center justify-between mb-2">
+            <div className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray">
+              Legend
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              aria-label="Close legend"
+              className="p-0.5 rounded-sm text-warm-gray hover:bg-silver-light hover:text-charcoal cursor-pointer transition-colors"
+            >
+              <X size={12} strokeWidth={1.5} />
+            </button>
+          </div>
+          <ul className="space-y-2">
+            <li className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="inline-block h-3 w-3 rounded-full bg-orange-brand border-2 border-white shadow-[0_1px_2px_rgba(0,0,0,0.2)] shrink-0"
+              />
+              <span className="text-[12px] text-charcoal leading-snug">
+                Initial Planning Point
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="inline-block h-2.5 w-2.5 rounded-full bg-ink border-2 border-white shadow-[0_1px_2px_rgba(0,0,0,0.2)] shrink-0"
+              />
+              <span className="text-[12px] text-charcoal leading-snug">
+                Direction of Travel
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="inline-block w-4 shrink-0"
+                style={{ borderTop: "1.5px solid #e25b2a", opacity: 0.8 }}
+              />
+              <span className="text-[12px] text-charcoal leading-snug">
+                Probability rings (25/50/75/95%)
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="inline-block w-4 shrink-0"
+                style={{ borderTop: "2px solid #3a3632", opacity: 0.85 }}
+              />
+              <span className="text-[12px] text-charcoal leading-snug">
+                Direction line
+              </span>
+            </li>
+            <li className="flex items-center gap-2.5">
+              <span
+                aria-hidden
+                className="inline-block w-4 shrink-0"
+                style={{ borderTop: "1px solid #6e6960", opacity: 0.5 }}
+              />
+              <span className="text-[12px] text-charcoal leading-snug">
+                Dispersion bounds
+              </span>
+            </li>
+          </ul>
+          <div className="mt-3 pt-2 border-t border-rule font-mono text-[9px] uppercase tracking-[0.12em] text-warm-gray leading-relaxed">
+            {isMobile ? "Long-press" : "Right-click"} the map to place a marker
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          aria-label="Open legend"
+          className="flex items-center justify-center h-[29px] w-[29px] bg-white rounded-lg shadow-[0_1px_4px_rgba(0,0,0,0.06),0_0_0_1px_var(--plk-rule-strong)] text-charcoal hover:bg-snow cursor-pointer transition-colors"
+        >
+          <Info size={14} strokeWidth={1.75} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/MapContextMenu.tsx
+++ b/src/components/MapContextMenu.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Crosshair, Navigation } from "lucide-react";
+
+interface Props {
+  x: number;
+  y: number;
+  hasIpp: boolean;
+  hasDirection: boolean;
+  onPlaceIpp: () => void;
+  onPlaceDirection: () => void;
+  onClose: () => void;
+}
+
+const MENU_OFFSET = 4;
+
+export default function MapContextMenu({
+  x,
+  y,
+  hasIpp,
+  hasDirection,
+  onPlaceIpp,
+  onPlaceDirection,
+  onClose,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ left: x + MENU_OFFSET, top: y + MENU_OFFSET });
+
+  useLayoutEffect(() => {
+    const node = ref.current;
+    const parent = node?.offsetParent as HTMLElement | null;
+    if (!node || !parent) return;
+    const menuRect = node.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+    let left = x + MENU_OFFSET;
+    let top = y + MENU_OFFSET;
+    if (left + menuRect.width > parentRect.width - 8) {
+      left = Math.max(8, x - menuRect.width - MENU_OFFSET);
+    }
+    if (top + menuRect.height > parentRect.height - 8) {
+      top = Math.max(8, y - menuRect.height - MENU_OFFSET);
+    }
+    setPos({ left, top });
+  }, [x, y]);
+
+  useEffect(() => {
+    const onPointerDown = (e: MouseEvent | TouchEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("touchstart", onPointerDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("touchstart", onPointerDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      aria-label="Place marker"
+      className="sar-map-context-menu absolute z-20 min-w-[220px] bg-white rounded-md border border-rule-strong overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.10),0_1px_3px_rgba(0,0,0,0.04)]"
+      style={{ left: pos.left, top: pos.top }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <button
+        role="menuitem"
+        onClick={() => {
+          onPlaceIpp();
+          onClose();
+        }}
+        className="flex items-center gap-2 w-full text-left px-3 py-2.5 sm:py-2 font-mono text-[11px] uppercase tracking-[0.12em] text-charcoal hover:bg-snow cursor-pointer"
+      >
+        <Crosshair size={13} strokeWidth={1.75} className="text-orange-brand" />
+        {hasIpp ? "Move planning point here" : "Place planning point"}
+      </button>
+      <button
+        role="menuitem"
+        onClick={() => {
+          onPlaceDirection();
+          onClose();
+        }}
+        className="flex items-center gap-2 w-full text-left px-3 py-2.5 sm:py-2 font-mono text-[11px] uppercase tracking-[0.12em] text-charcoal hover:bg-snow border-t border-rule cursor-pointer"
+      >
+        <Navigation size={13} strokeWidth={1.75} />
+        {hasDirection ? "Move direction here" : "Place direction"}
+      </button>
+    </div>
+  );
+}

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -33,7 +33,52 @@ export default class SearchMap extends EventEmitter {
     }));
     this.map.on('load', data => this.emit('load', data));
     this.map.on('move', data => this.emit('move', data))
+    this.map.on('contextmenu', evt => {
+      if(evt.originalEvent && typeof evt.originalEvent.preventDefault === 'function') {
+        evt.originalEvent.preventDefault();
+      }
+      this.emit('contextmenu', { lngLat: evt.lngLat, point: evt.point, originalEvent: evt.originalEvent });
+    });
+    this._attachLongPressHandler();
     this.statsLayer.addTo(this.map);
+  }
+  _attachLongPressHandler() {
+    if(!this.map) return;
+    const container = this.map.getContainer();
+    let pressTimer = null;
+    let pressStart = null;
+    const cancel = () => {
+      if(pressTimer) {
+        clearTimeout(pressTimer);
+        pressTimer = null;
+      }
+      pressStart = null;
+    };
+    const isOnInteractive = (target) => {
+      if(!target || typeof target.closest !== 'function') return false;
+      return Boolean(target.closest('.mapboxgl-marker, .mapboxgl-ctrl, .mapboxgl-popup, .sar-map-context-menu'));
+    };
+    container.addEventListener('touchstart', (e) => {
+      if(e.touches.length !== 1) { cancel(); return; }
+      if(isOnInteractive(e.target)) return;
+      const t = e.touches[0];
+      pressStart = { x: t.clientX, y: t.clientY };
+      pressTimer = setTimeout(() => {
+        if(!pressStart || !this.map) return;
+        const rect = container.getBoundingClientRect();
+        const point = { x: pressStart.x - rect.left, y: pressStart.y - rect.top };
+        const lngLat = this.map.unproject([point.x, point.y]);
+        this.emit('contextmenu', { lngLat, point, originalEvent: e });
+        pressTimer = null;
+      }, 500);
+    }, { passive: true });
+    container.addEventListener('touchmove', (e) => {
+      if(!pressTimer || !pressStart) return;
+      const t = e.touches[0];
+      if(Math.hypot(t.clientX - pressStart.x, t.clientY - pressStart.y) > 10) cancel();
+    }, { passive: true });
+    container.addEventListener('touchend', cancel);
+    container.addEventListener('touchcancel', cancel);
   }
   resize() {
     if(this.map) this.map.resize();


### PR DESCRIPTION
## Summary
This PR adds a legend component and context menu functionality to the map, allowing users to place and manage markers (Initial Planning Point and Direction) via right-click (desktop) or long-press (mobile) interactions.

## Key Changes
- **Legend Component** (`Legend.tsx`): New collapsible legend panel that displays map symbols and instructions. Automatically collapses on mobile devices (≤720px) and includes responsive instructions for marker placement (right-click on desktop, long-press on mobile).

- **Context Menu Component** (`MapContextMenu.tsx`): New context menu that appears at the cursor/touch position with options to place or move the Initial Planning Point and Direction markers. Includes smart positioning to keep the menu within viewport bounds.

- **Map Integration** (`SearchMap.ts`): 
  - Added `contextmenu` event listener to handle right-click events
  - Implemented `_attachLongPressHandler()` for mobile long-press detection (500ms threshold with 10px movement tolerance)
  - Prevents default context menu behavior and emits custom events with map coordinates

- **App Component** (`App.tsx`):
  - Integrated Legend and MapContextMenu components
  - Added context menu state management
  - Connected context menu actions to existing marker placement methods (`setIPPMarker`, `setDestinationMarker`)
  - Prevented default browser context menu on map container

## Notable Implementation Details
- Long-press detection uses a 500ms timer with movement tolerance to distinguish from scrolling
- Context menu automatically closes when clicking outside or pressing Escape
- Menu positioning accounts for viewport boundaries with 8px padding
- Mobile detection uses CSS media query for responsive behavior
- Accessibility features include proper ARIA labels and semantic HTML (role="menu", role="menuitem")

https://claude.ai/code/session_01Uafg2tmu8qYbtCUrGXwgcQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate UI/input-handling change: introduces new map `contextmenu`/long-press listeners and a custom menu, which could conflict with existing map interactions or touch scrolling if edge cases are missed.
> 
> **Overview**
> Adds an on-map **legend** panel (collapsible, auto-collapses on mobile) to explain marker/ring/line visuals and instruct users to right-click/long-press to place markers.
> 
> Introduces a **map context menu** that opens on right-click (desktop) or long-press (mobile) and lets users place/move the IPP and direction markers; `App.tsx` now tracks context-menu state and wires actions to `searchMap.setIPPMarker`/`setDestinationMarker` while preventing the browser default context menu.
> 
> Extends `SearchMap` to emit a custom `contextmenu` event from Mapbox’s `contextmenu` plus a new touch long-press detector (500ms with movement tolerance), skipping interactive elements and passing map point/lngLat to the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f20c3c4a144cfd14b257a4291b631ddc4a8590. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->