### PR TITLE
Replace dispersion lines with probability heatmap visualization

### DIFF
--- a/src/services/statistics/StatisticsVirtualLayer.ts
+++ b/src/services/statistics/StatisticsVirtualLayer.ts
@@ -1,59 +1,70 @@
 import {
-  createRingsLayer,
   createRingLabelsLayer,
-  createDispersionLinesLayer,
-  createDirectionLineLayer
+  createDirectionLineLayer,
+  createHeatmapLayer,
 } from './geometry';
 
 export default class StatisticsVirtualLayer {
   constructor() {
     this.map = null;
     this.layers = {
-      rings: null,
+      heatmap: null,
       labels: null,
-      dispersionLines: null,
-      directionLine: null
-    }
+      directionLine: null,
+    };
+    this.ipp = null;
+    this.destination = null;
+    this.behavior = null;
   }
   addTo(map) {
     this.map = map;
   }
-  clearRings() {
-    if(!this.map) return null;
-    if(this.layers.rings) {
-      this.layers.rings.remove();
-      this.layers.rings = null;
-    }
-    if(this.layers.labels) {
-      this.layers.labels.remove();
-      this.layers.labels = null;
+  _removeLayer(key) {
+    if (this.layers[key]) {
+      this.layers[key].remove();
+      this.layers[key] = null;
     }
   }
-  clearDispersion = () => {
-    if(!this.map) return null;
-    if(this.layers.dispersionLines) {
-      this.layers.dispersionLines.remove();
-      this.layers.dispersionLines = null;
+  _render() {
+    if (!this.map) return;
+    this._removeLayer('heatmap');
+    this._removeLayer('directionLine');
+    this._removeLayer('labels');
+
+    if (!this.ipp || !this.behavior) return;
+
+    const ippLngLat = this.ipp.getLngLat();
+    const destLngLat = this.destination ? this.destination.getLngLat() : null;
+
+    this.layers.heatmap = createHeatmapLayer(ippLngLat, destLngLat, this.behavior);
+    this.layers.heatmap.addTo(this.map);
+
+    if (destLngLat) {
+      this.layers.directionLine = createDirectionLineLayer(ippLngLat, destLngLat);
+      this.layers.directionLine.addTo(this.map);
     }
-    if(this.layers.directionLine) {
-      this.layers.directionLine.remove();
-      this.layers.directionLine = null;
-    }
-  }
-  drawRings = (ipp, behavior) => {
-    if(!this.map) return null;
-    this.clearRings();
-    this.layers.rings = createRingsLayer(ipp.getLngLat(), behavior);
-    this.layers.labels = createRingLabelsLayer(ipp.getLngLat(), behavior);
-    this.layers.rings.addTo(this.map);
+
+    this.layers.labels = createRingLabelsLayer(ippLngLat, this.behavior);
     this.layers.labels.addTo(this.map);
   }
+  clearRings = () => {
+    this.ipp = null;
+    this.behavior = null;
+    this._render();
+  };
+  clearDispersion = () => {
+    this.destination = null;
+    this._render();
+  };
+  drawRings = (ipp, behavior) => {
+    this.ipp = ipp;
+    this.behavior = behavior;
+    this._render();
+  };
   drawDispersion(ipp, destination, behavior) {
-    if(!this.map) return null;
-    this.clearDispersion();
-    this.layers.dispersionLines = createDispersionLinesLayer(ipp.getLngLat(), destination.getLngLat(), behavior);
-    this.layers.directionLine = createDirectionLineLayer(ipp.getLngLat(), destination.getLngLat());
-    this.layers.dispersionLines.addTo(this.map);
-    this.layers.directionLine.addTo(this.map);
+    this.ipp = ipp;
+    this.destination = destination;
+    this.behavior = behavior;
+    this._render();
   }
 }

--- a/src/services/statistics/StatisticsVirtualLayer.ts
+++ b/src/services/statistics/StatisticsVirtualLayer.ts
@@ -66,6 +66,7 @@ export default class StatisticsVirtualLayer {
   }
   clearRings = () => {
     this.ipp = null;
+    this.destination = null;
     this.behavior = null;
     this._render();
   };
@@ -75,6 +76,7 @@ export default class StatisticsVirtualLayer {
   };
   drawRings = (ipp: MapMarker, behavior: BehaviorData) => {
     this.ipp = ipp;
+    this.destination = null;
     this.behavior = behavior;
     this._render();
   };

--- a/src/services/statistics/geometry.ts
+++ b/src/services/statistics/geometry.ts
@@ -189,9 +189,20 @@ function computeProbabilityCells(ippLngLat, destinationLngLat, behavior) {
     }
   }
 
-  const maxDensity = Math.max(...cells.map(c => c.density));
+  // Anchor color scale to a density that is independent of whether a
+  // direction marker is set, so the colormap stays comparable across modes.
+  // Reference = mean density inside the innermost ring under a uniform
+  // distribution (no direction). Cells denser than the reference clip to 1.
+  const refDensity = distances[0] > 0
+    ? cumDistProbs[0] / (Math.PI * distances[0] * distances[0])
+    : 0;
   cells.forEach(c => {
-    c.intensity = maxDensity > 0 ? Math.pow(c.density / maxDensity, 0.25) : 0;
+    if (refDensity <= 0) {
+      c.intensity = 0;
+      return;
+    }
+    const ratio = c.density / refDensity;
+    c.intensity = Math.min(1, Math.pow(ratio, 0.25));
   });
 
   return cells;

--- a/src/services/statistics/geometry.ts
+++ b/src/services/statistics/geometry.ts
@@ -179,19 +179,29 @@ function computeProbabilityCells(
     baseAngle = dest.getBearingTo(ipp);
     const { angles } = behavior.getDispersion();
     const cumAng = [0.25, 0.50, 0.75, 0.95];
-    const halfBand = (i: number) => (i === 0 ? cumAng[0] : cumAng[i] - cumAng[i - 1]) / 2;
+    const rearProb = 1 - cumAng[3];
+    // Cap the outer angle so the forward bands never overlap behind the
+    // marker. If p95 reaches the cap, there is no rear span left, so fold
+    // the rear probability into the outermost forward bands instead.
+    const p95 = Math.min(angles[3], 179.99);
+    const noRearSpan = p95 >= 180 - 0.01;
+    const outerBoost = noRearSpan ? rearProb / 2 : 0;
+    const halfBand = (i: number) => {
+      const base = (i === 0 ? cumAng[0] : cumAng[i] - cumAng[i - 1]) / 2;
+      return i === 3 ? base + outerBoost : base;
+    };
     angBands = [
       { start: 0, end: angles[0], prob: halfBand(0) },
       { start: angles[0], end: angles[1], prob: halfBand(1) },
       { start: angles[1], end: angles[2], prob: halfBand(2) },
-      { start: angles[2], end: angles[3], prob: halfBand(3) },
+      { start: angles[2], end: p95, prob: halfBand(3) },
       { start: -angles[0], end: 0, prob: halfBand(0) },
       { start: -angles[1], end: -angles[0], prob: halfBand(1) },
       { start: -angles[2], end: -angles[1], prob: halfBand(2) },
-      { start: -angles[3], end: -angles[2], prob: halfBand(3) },
+      { start: -p95, end: -angles[2], prob: halfBand(3) },
     ];
-    if (angles[3] < 180) {
-      angBands.push({ start: angles[3], end: 360 - angles[3], prob: 0.05 });
+    if (!noRearSpan) {
+      angBands.push({ start: p95, end: 360 - p95, prob: rearProb });
     }
   } else {
     angBands = [{ start: 0, end: 360, prob: 1.0 }];

--- a/src/services/statistics/geometry.ts
+++ b/src/services/statistics/geometry.ts
@@ -98,6 +98,152 @@ export function createDirectionLineLayer(ippLngLat, directionLngLat) {
     }
   })
 }
+function buildSectorPolygon(centerLngLat, innerRadius, outerRadius, startBearing, endBearing) {
+  const c = new LngLat(centerLngLat);
+  const angleSpan = endBearing - startBearing;
+  const isFullCircle = Math.abs(angleSpan) >= 360 - 1e-6;
+  const numSamples = Math.max(8, Math.ceil(Math.abs(angleSpan) / 5));
+  const step = angleSpan / numSamples;
+  const outerPts = [];
+  for (let i = 0; i <= numSamples; i++) {
+    const p = c.moveTo(startBearing + step * i, outerRadius);
+    outerPts.push([p.lng, p.lat]);
+  }
+  if (isFullCircle) {
+    if (innerRadius === 0) {
+      return { type: 'Polygon', coordinates: [outerPts] };
+    }
+    const innerPts = [];
+    for (let i = numSamples; i >= 0; i--) {
+      const p = c.moveTo(startBearing + step * i, innerRadius);
+      innerPts.push([p.lng, p.lat]);
+    }
+    return { type: 'Polygon', coordinates: [outerPts, innerPts] };
+  }
+  if (innerRadius === 0) {
+    const ring = [[c.lng, c.lat], ...outerPts, [c.lng, c.lat]];
+    return { type: 'Polygon', coordinates: [ring] };
+  }
+  const innerPts = [];
+  for (let i = numSamples; i >= 0; i--) {
+    const p = c.moveTo(startBearing + step * i, innerRadius);
+    innerPts.push([p.lng, p.lat]);
+  }
+  const ring = [...outerPts, ...innerPts, outerPts[0]];
+  return { type: 'Polygon', coordinates: [ring] };
+}
+
+function computeProbabilityCells(ippLngLat, destinationLngLat, behavior) {
+  const distances = behavior.getDistanceProbabilities().map(d => d.value * 1000);
+  const cumDistProbs = [0.25, 0.50, 0.75, 0.95];
+  const distBands = [
+    { inner: 0, outer: distances[0], prob: cumDistProbs[0] },
+    { inner: distances[0], outer: distances[1], prob: cumDistProbs[1] - cumDistProbs[0] },
+    { inner: distances[1], outer: distances[2], prob: cumDistProbs[2] - cumDistProbs[1] },
+    { inner: distances[2], outer: distances[3], prob: cumDistProbs[3] - cumDistProbs[2] },
+  ];
+
+  let baseAngle = 0;
+  let angBands;
+
+  if (destinationLngLat) {
+    const ipp = new LngLat(ippLngLat);
+    const dest = new LngLat(destinationLngLat);
+    baseAngle = dest.getBearingTo(ipp);
+    const { angles } = behavior.getDispersion();
+    const cumAng = [0.25, 0.50, 0.75, 0.95];
+    const halfBand = i => (i === 0 ? cumAng[0] : cumAng[i] - cumAng[i - 1]) / 2;
+    angBands = [
+      { start: 0, end: angles[0], prob: halfBand(0) },
+      { start: angles[0], end: angles[1], prob: halfBand(1) },
+      { start: angles[1], end: angles[2], prob: halfBand(2) },
+      { start: angles[2], end: angles[3], prob: halfBand(3) },
+      { start: -angles[0], end: 0, prob: halfBand(0) },
+      { start: -angles[1], end: -angles[0], prob: halfBand(1) },
+      { start: -angles[2], end: -angles[1], prob: halfBand(2) },
+      { start: -angles[3], end: -angles[2], prob: halfBand(3) },
+    ];
+    if (angles[3] < 180) {
+      angBands.push({ start: angles[3], end: 360 - angles[3], prob: 0.05 });
+    }
+  } else {
+    angBands = [{ start: 0, end: 360, prob: 1.0 }];
+  }
+
+  const cells = [];
+  for (const dist of distBands) {
+    const ringArea = Math.PI * (dist.outer * dist.outer - dist.inner * dist.inner);
+    for (const ang of angBands) {
+      const angularFraction = (ang.end - ang.start) / 360;
+      const cellArea = ringArea * angularFraction;
+      const probability = dist.prob * ang.prob;
+      const density = cellArea > 0 ? probability / cellArea : 0;
+      const polygon = buildSectorPolygon(
+        ippLngLat,
+        dist.inner,
+        dist.outer,
+        baseAngle + ang.start,
+        baseAngle + ang.end,
+      );
+      cells.push({ polygon, density, probability });
+    }
+  }
+
+  const maxDensity = Math.max(...cells.map(c => c.density));
+  cells.forEach(c => {
+    c.intensity = maxDensity > 0 ? Math.pow(c.density / maxDensity, 0.25) : 0;
+  });
+
+  return cells;
+}
+
+export function createHeatmapLayer(ippLngLat, destinationLngLat, behavior) {
+  behavior = new StatisticalBehavior(behavior);
+  const cells = computeProbabilityCells(ippLngLat, destinationLngLat, behavior);
+  const features = cells.map(cell => ({
+    type: 'Feature',
+    properties: {
+      name: 'Probability',
+      density: cell.density,
+      intensity: cell.intensity,
+      probability: cell.probability,
+    },
+    geometry: cell.polygon,
+  }));
+  return new MapStyleLayer({
+    id: 'probability-heatmap',
+    type: 'fill',
+    source: {
+      type: 'geojson',
+      data: {
+        type: 'FeatureCollection',
+        features,
+      },
+    },
+    layout: {},
+    paint: {
+      'fill-color': [
+        'interpolate',
+        ['linear'],
+        ['get', 'intensity'],
+        0,    '#2c7bb6',
+        0.25, '#abd9e9',
+        0.5,  '#ffffbf',
+        0.75, '#fdae61',
+        1,    '#d7191c',
+      ],
+      'fill-opacity': [
+        'interpolate',
+        ['linear'],
+        ['get', 'intensity'],
+        0,   0.15,
+        1,   0.6,
+      ],
+      'fill-outline-color': 'rgba(0,0,0,0.05)',
+    },
+  });
+}
+
 export function createDispersionLinesLayer(ippLngLat, destinationLngLat, behavior) {
   ippLngLat = new LngLat(ippLngLat);
   destinationLngLat = new LngLat(destinationLngLat);


### PR DESCRIPTION
## Summary
This PR replaces the dispersion lines visualization with a probability heatmap that displays statistical behavior data as colored sectors on the map. The heatmap uses a color gradient to represent probability density across distance and angular bands.

## Key Changes

- **New heatmap visualization**: Added `buildSectorPolygon()` function to construct GeoJSON polygon geometries for sector rings, handling both full circles and partial sectors with optional inner radii
- **Probability cell computation**: Implemented `computeProbabilityCells()` to calculate probability density for each combination of distance and angular bands, with intensity normalization for visual rendering
- **New heatmap layer**: Added `createHeatmapLayer()` export that generates a MapBox fill layer with color interpolation based on probability intensity (blue → red gradient)
- **Refactored layer management**: Simplified `StatisticsVirtualLayer` to use a unified `_render()` method that manages all layer lifecycle, replacing separate `clearRings()` and `clearDispersion()` implementations
- **State-based rendering**: Changed from imperative layer creation to state-based approach where `ipp`, `destination`, and `behavior` are stored and `_render()` is called to update the visualization
- **Removed dispersion lines**: Eliminated `createDispersionLinesLayer()` import and usage in favor of the new heatmap approach

## Implementation Details

- Sector polygons are sampled at 5-degree intervals (minimum 8 samples) for smooth curved edges
- Probability density is calculated as `probability / cellArea` and normalized using a 0.25 power curve for better visual distribution
- Heatmap uses a 5-color scheme with opacity interpolation (0.15 at minimum intensity, 0.6 at maximum)
- Layer removal is now centralized through `_removeLayer()` helper method

https://claude.ai/code/session_016hLwsg3BvACLZwDDXjLDUh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: replaces map rendering logic for statistical visualization with new polygon/heatmap generation and centralized re-rendering, which could affect map performance and visual correctness.
> 
> **Overview**
> Replaces the dispersion-line visualization with a **probability heatmap** rendered as GeoJSON sector polygons, colored by normalized probability density, and keeps the destination direction line as an overlay.
> 
> Refactors `StatisticsVirtualLayer` to a state-driven `_render()` flow that stores `ipp`/`destination`/`behavior`, centralizes layer teardown via `_removeLayer()`, and re-renders heatmap/labels/direction line on `draw*`/`clear*` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6763830c9d2f95cdb95987d7c76dddf4a3bc611c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->