### PR TITLE
Fix duplicate contextmenu events on Android Chrome long-press

### DIFF
--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -37,6 +37,12 @@ export default class SearchMap extends EventEmitter {
       if(evt.originalEvent && typeof evt.originalEvent.preventDefault === 'function') {
         evt.originalEvent.preventDefault();
       }
+      // Android Chrome fires a native contextmenu during a long-press touch in addition
+      // to our custom long-press timer. Dedupe so only one emission reaches listeners.
+      if(this._touchActive) {
+        if(this._contextmenuEmittedDuringTouch) return;
+        this._contextmenuEmittedDuringTouch = true;
+      }
       this.emit('contextmenu', { lngLat: evt.lngLat, point: evt.point, originalEvent: evt.originalEvent });
     });
     this._attachLongPressHandler();
@@ -53,6 +59,8 @@ export default class SearchMap extends EventEmitter {
         pressTimer = null;
       }
       pressStart = null;
+      this._touchActive = false;
+      this._contextmenuEmittedDuringTouch = false;
     };
     const isOnInteractive = (target) => {
       if(!target || typeof target.closest !== 'function') return false;
@@ -62,14 +70,18 @@ export default class SearchMap extends EventEmitter {
       if(e.touches.length !== 1) { cancel(); return; }
       if(isOnInteractive(e.target)) return;
       const t = e.touches[0];
+      this._touchActive = true;
+      this._contextmenuEmittedDuringTouch = false;
       pressStart = { x: t.clientX, y: t.clientY };
       pressTimer = setTimeout(() => {
+        pressTimer = null;
         if(!pressStart || !this.map) return;
+        if(this._contextmenuEmittedDuringTouch) return;
+        this._contextmenuEmittedDuringTouch = true;
         const rect = container.getBoundingClientRect();
         const point = { x: pressStart.x - rect.left, y: pressStart.y - rect.top };
         const lngLat = this.map.unproject([point.x, point.y]);
         this.emit('contextmenu', { lngLat, point, originalEvent: e });
-        pressTimer = null;
       }, 500);
     }, { passive: true });
     container.addEventListener('touchmove', (e) => {


### PR DESCRIPTION
## Summary
Fixed an issue where Android Chrome fires both a native contextmenu event and a custom long-press timer event during touch interactions, resulting in duplicate contextmenu emissions to listeners.

## Key Changes
- Added `_touchActive` and `_contextmenuEmittedDuringTouch` flags to track touch state and prevent duplicate emissions
- Modified the native contextmenu handler to skip emission if one was already emitted during the current touch interaction
- Updated the long-press touch handler to:
  - Set `_touchActive = true` when a touch begins
  - Reset both flags when touch ends
  - Check if contextmenu was already emitted before firing the long-press timer event
  - Set the flag when emitting from the timer to prevent the native handler from also emitting

## Implementation Details
- The deduplication logic ensures that only one contextmenu event reaches listeners per touch interaction, regardless of whether it comes from the native browser event or the custom 500ms long-press timer
- Flags are properly reset on touch end to handle subsequent touch interactions correctly
- The `pressTimer = null` assignment was moved inside the timeout callback for better cleanup ordering

https://claude.ai/code/session_0188UQpmFenaX6nL5yXpUxNE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to touch/contextmenu event handling that could affect how often `contextmenu` is emitted on mobile devices.
> 
> **Overview**
> Prevents duplicate `contextmenu` emissions on Android Chrome long-press by deduplicating between the browser-native `contextmenu` event and the custom 500ms long-press timer.
> 
> Adds per-touch state flags (`_touchActive`, `_contextmenuEmittedDuringTouch`) that are set/reset on touch start/end and checked in both handlers, with minor timer cleanup ordering (`pressTimer = null` inside the timeout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e969f12c52addc9ab41ea4b3316bf1a352ba045f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->