### PR TITLE
Add Plucky attribution link to Navbar footer

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -245,6 +245,13 @@ export default function Navbar({ setBehaviorByKeys }: NavbarProps) {
                   className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
                 >
                   Ryan Villanueva
+                </a>{" "}
+                at{" "}
+                <a
+                  href="https://plucky.ai"
+                  className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
+                >
+                  Plucky
                 </a>
                 .
               </p>


### PR DESCRIPTION
## Summary
Updated the Navbar component's footer attribution to include a link to Plucky, the organization where Ryan Villanueva works.

## Changes
- Added a link to https://plucky.ai in the Navbar footer text
- Maintained consistent styling with the existing Ryan Villanueva link using the same `text-orange-brand hover:text-charcoal transition-colors underline-offset-2` classes
- Updated the attribution text to read "Ryan Villanueva at Plucky" instead of just "Ryan Villanueva"

## Implementation Details
The new link follows the same styling pattern as the existing attribution link, ensuring visual consistency in the footer. The text now properly attributes the work to both the individual contributor and their organization.

https://claude.ai/code/session_01X27GWczRF4XtTRfXHUxJit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only text/link change in the `Navbar` About modal with no logic, data, or security impact.
> 
> **Overview**
> Updates the `Navbar` About/colophon attribution copy to credit “Ryan Villanueva at Plucky” by adding a new `https://plucky.ai` link styled consistently with the existing attribution link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5814cfca993fe29698f6494dfb18eba4ae31304. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->