### PR TITLE
Migrate newsletter subscription to Loops and add form state management

### DIFF
--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -45,15 +45,16 @@ export default function Subscribe() {
       }
 
       const data = await res.json().catch(() => null);
+      localStorage.removeItem(RATE_LIMIT_KEY);
       setStatus('error');
       setErrorMessage(data?.message ?? res.statusText);
     } catch (error) {
-      if (error instanceof Error && error.message === 'Failed to fetch') {
+      if (error instanceof TypeError) {
         setStatus('error');
         setErrorMessage('Too many signups, please try again in a little while');
         return;
       }
-      localStorage.setItem(RATE_LIMIT_KEY, '');
+      localStorage.removeItem(RATE_LIMIT_KEY);
       setStatus('error');
       setErrorMessage(
         error instanceof Error && error.message

--- a/src/components/Subscribe.tsx
+++ b/src/components/Subscribe.tsx
@@ -1,7 +1,67 @@
 import { useState } from 'react';
 
+const LOOPS_FORM_URL =
+  'https://app.loops.so/api/newsletter-form/cmoukeakw05640i1ejr2oq33w';
+const RATE_LIMIT_KEY = 'loops-form-timestamp';
+const RATE_LIMIT_MS = 60_000;
+
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
 export default function Subscribe() {
   const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const reset = () => {
+    setStatus('idle');
+    setErrorMessage('');
+    setEmail('');
+  };
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const previous = Number(localStorage.getItem(RATE_LIMIT_KEY) ?? 0);
+    if (previous && previous + RATE_LIMIT_MS > Date.now()) {
+      setStatus('error');
+      setErrorMessage('Too many signups, please try again in a little while');
+      return;
+    }
+    localStorage.setItem(RATE_LIMIT_KEY, String(Date.now()));
+
+    setStatus('loading');
+
+    try {
+      const body = `userGroup=&mailingLists=&email=${encodeURIComponent(email)}`;
+      const res = await fetch(LOOPS_FORM_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      });
+
+      if (res.ok) {
+        setStatus('success');
+        return;
+      }
+
+      const data = await res.json().catch(() => null);
+      setStatus('error');
+      setErrorMessage(data?.message ?? res.statusText);
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Failed to fetch') {
+        setStatus('error');
+        setErrorMessage('Too many signups, please try again in a little while');
+        return;
+      }
+      localStorage.setItem(RATE_LIMIT_KEY, '');
+      setStatus('error');
+      setErrorMessage(
+        error instanceof Error && error.message
+          ? error.message
+          : 'Oops! Something went wrong, please try again',
+      );
+    }
+  }
 
   return (
     <div>
@@ -11,34 +71,56 @@ export default function Subscribe() {
       <p className="text-[13px] text-slate-warm font-light mb-3 leading-relaxed">
         Sign up to hear about feature releases.
       </p>
-      <form
-        action="https://sarmapper.us20.list-manage.com/subscribe/post?u=65b955fa7c92f8be66eec94cc&amp;id=b2b2fef9ac"
-        method="post"
-        name="mc-embedded-subscribe-form"
-        target="_blank"
-        noValidate
-      >
-        <div className="flex">
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            name="EMAIL"
-            placeholder="email@address"
-            required
-            className="flex-1 rounded-l-sm border border-rule-strong border-r-0 bg-white px-3 py-2 font-mono text-[12px] text-charcoal outline-none focus:border-charcoal transition-colors placeholder:text-warm-gray"
-          />
-          <div className="absolute -left-[5000px]" aria-hidden="true">
-            <input type="text" name="b_65b955fa7c92f8be66eec94cc_b2b2fef9ac" tabIndex={-1} defaultValue="" />
-          </div>
-          <input
-            type="submit"
-            value="Subscribe"
-            name="subscribe"
-            className="rounded-r-sm bg-ink px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white hover:bg-charcoal transition-colors cursor-pointer border-0"
-          />
+
+      {status === 'success' ? (
+        <div className="flex items-center justify-between">
+          <p className="text-[13px] text-slate-warm font-light leading-relaxed m-0">
+            Thanks! We'll be in touch.
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-warm-gray hover:text-charcoal transition-colors cursor-pointer bg-transparent border-0 p-0"
+          >
+            ← Back
+          </button>
         </div>
-      </form>
+      ) : status === 'error' ? (
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-[13px] text-red-700 font-light leading-relaxed m-0">
+            {errorMessage || 'Oops! Something went wrong, please try again'}
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-warm-gray hover:text-charcoal transition-colors cursor-pointer bg-transparent border-0 p-0 whitespace-nowrap"
+          >
+            ← Back
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="flex">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              name="email"
+              placeholder="email@address"
+              required
+              disabled={status === 'loading'}
+              className="flex-1 rounded-l-sm border border-rule-strong border-r-0 bg-white px-3 py-2 font-mono text-[12px] text-charcoal outline-none focus:border-charcoal transition-colors placeholder:text-warm-gray disabled:opacity-60"
+            />
+            <button
+              type="submit"
+              disabled={status === 'loading'}
+              className="rounded-r-sm bg-ink px-4 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-white hover:bg-charcoal transition-colors cursor-pointer border-0 disabled:opacity-60 disabled:cursor-wait"
+            >
+              {status === 'loading' ? 'Please wait…' : 'Subscribe'}
+            </button>
+          </div>
+        </form>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Migrated the newsletter subscription form from Mailchimp to Loops and implemented comprehensive form state management with success/error handling and client-side rate limiting.

## Key Changes
- **Email service migration**: Replaced Mailchimp integration with Loops API endpoint
- **Form state management**: Added status tracking (idle, loading, success, error) and error messaging
- **Client-side rate limiting**: Implemented 60-second rate limit using localStorage to prevent spam submissions
- **Enhanced UX**: 
  - Added loading state with visual feedback ("Please wait…" button text)
  - Displays success message with option to reset form
  - Shows error messages with user-friendly fallbacks
  - Disables inputs during submission
- **Error handling**: Comprehensive try-catch with specific handling for network failures and API errors
- **Form submission**: Changed from form action to client-side `handleSubmit` handler with proper event handling

## Implementation Details
- Rate limiting is stored in localStorage with key `loops-form-timestamp` and 60-second window
- Form resets to idle state via `reset()` function accessible from success/error states
- Disabled state styling applied to inputs during loading to prevent multiple submissions
- Error messages from API response are displayed, with fallback to status text or generic message
- Network failures ("Failed to fetch") are treated as rate limit errors with user-friendly messaging

https://claude.ai/code/session_01Njyg1EXJsE94v3STEV3jSN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the newsletter signup integration from a simple external form post to in-app `fetch` logic with localStorage-based rate limiting, which could affect signup reliability and error handling across browsers.
> 
> **Overview**
> Migrates the newsletter signup in `Subscribe.tsx` from a Mailchimp form `action` to a Loops API `POST`, handled client-side via `fetch`.
> 
> Adds form state management (`idle`/`loading`/`success`/`error`) with disabled controls during submission, success/error UI with a reset/back action, and a simple 60s client-side rate limit using `localStorage` (including special-casing `Failed to fetch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d7b2792dc67478442f0756fdd376c4569cf17a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->