### PR TITLE
Redesign about section with definition list layout

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -241,45 +241,65 @@ export default function Navbar({
                 <X size={18} strokeWidth={1.5} />
               </Dialog.Close>
             </div>
-            <div className="text-[14.5px] text-slate-warm space-y-4 leading-relaxed font-light">
-              <p className="m-0">
-                Interface and visualization designed by{" "}
-                <a
-                  href="mailto:ryan@sarmapper.org"
-                  className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
-                >
-                  Ryan Villanueva
-                </a>{" "}
-                at{" "}
-                <a
-                  href="https://plucky.ai"
-                  className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
-                >
-                  Plucky
-                </a>
-                .
+            <div className="space-y-5">
+              <p className="text-[14.5px] text-slate-warm leading-relaxed font-light m-0">
+                A mapping tool that visualizes the statistical behavior of
+                lost persons to support Search and Rescue planning.
               </p>
-              <p className="m-0">
-                Statistical behavior data from{" "}
-                <a
-                  href="http://www.dbs-sar.com/"
-                  className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
-                >
-                  Lost Person Behavior
-                </a>{" "}
-                by Robert Koester.
-              </p>
-              <p className="m-0">
-                Open source code available on{" "}
-                <a
-                  href="https://github.com/rvillanueva/sarmapper"
-                  className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
-                >
-                  Github
-                </a>
-                .
-              </p>
-              <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-warm-gray leading-loose m-0 pt-3 border-t border-rule">
+
+              <dl className="grid grid-cols-[5.5rem_1fr] gap-x-4 gap-y-3 text-[13.5px] text-slate-warm font-light leading-relaxed m-0">
+                <dt className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray pt-[5px]">
+                  Design
+                </dt>
+                <dd className="m-0">
+                  Ryan Villanueva at{" "}
+                  <a
+                    href="https://plucky.ai"
+                    className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
+                  >
+                    Plucky
+                  </a>
+                </dd>
+
+                <dt className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray pt-[5px]">
+                  Data
+                </dt>
+                <dd className="m-0">
+                  <a
+                    href="http://www.dbs-sar.com/"
+                    className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
+                  >
+                    Lost Person Behavior
+                  </a>{" "}
+                  by Robert Koester
+                </dd>
+
+                <dt className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray pt-[5px]">
+                  Source
+                </dt>
+                <dd className="m-0">
+                  <a
+                    href="https://github.com/rvillanueva/sarmapper"
+                    className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
+                  >
+                    github.com/rvillanueva/sarmapper
+                  </a>
+                </dd>
+
+                <dt className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray pt-[5px]">
+                  Contact
+                </dt>
+                <dd className="m-0">
+                  <a
+                    href="mailto:ryan@sarmapper.org"
+                    className="font-mono text-[12px] text-charcoal hover:text-orange-brand transition-colors break-all"
+                  >
+                    ryan@sarmapper.org
+                  </a>
+                </dd>
+              </dl>
+
+              <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-warm-gray leading-loose m-0 pt-4 border-t border-rule">
                 The Lost Person Behavior Mapper does not guarantee the
                 information provided is fully accurate. It is intended as a
                 supplemental tool for Search and Rescue efforts and cannot

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Dialog } from "@base-ui/react/dialog";
-import { MapPin, BarChart3, Download, Info, X, Github } from "lucide-react";
+import { MapPin, BarChart3, Download, Info, X } from "lucide-react";
 import { useAppStore } from "../store/appStore";
 import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles";
 import { downloadGPX, downloadKML } from "../actions/downloadActions";
@@ -280,10 +280,9 @@ export default function Navbar({
                 <dd className="m-0">
                   <a
                     href="https://github.com/rvillanueva/sarmapper"
-                    aria-label="Source code on GitHub"
-                    className="inline-flex items-center text-charcoal hover:text-orange-brand transition-colors"
+                    className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
                   >
-                    <Github size={16} strokeWidth={1.75} />
+                    GitHub
                   </a>
                 </dd>
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { Dialog } from "@base-ui/react/dialog";
-import { MapPin, BarChart3, Download, Info, X } from "lucide-react";
+import { MapPin, BarChart3, Download, Info, X, Github } from "lucide-react";
 import { useAppStore } from "../store/appStore";
 import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles";
 import { downloadGPX, downloadKML } from "../actions/downloadActions";
@@ -280,9 +280,10 @@ export default function Navbar({
                 <dd className="m-0">
                   <a
                     href="https://github.com/rvillanueva/sarmapper"
-                    className="text-orange-brand hover:text-charcoal transition-colors underline-offset-2"
+                    aria-label="Source code on GitHub"
+                    className="inline-flex items-center text-charcoal hover:text-orange-brand transition-colors"
                   >
-                    github.com/rvillanueva/sarmapper
+                    <Github size={16} strokeWidth={1.75} />
                   </a>
                 </dd>
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -241,13 +241,13 @@ export default function Navbar({
                 <X size={18} strokeWidth={1.5} />
               </Dialog.Close>
             </div>
-            <div className="space-y-5">
+            <div>
               <p className="text-[14.5px] text-slate-warm leading-relaxed font-light m-0">
                 A mapping tool that visualizes the statistical behavior of
                 lost persons to support Search and Rescue planning.
               </p>
 
-              <dl className="grid grid-cols-[5.5rem_1fr] gap-x-4 gap-y-3 text-[13.5px] text-slate-warm font-light leading-relaxed m-0">
+              <dl className="mt-6 grid grid-cols-[5rem_1fr] gap-x-4 gap-y-2.5 text-[13.5px] text-slate-warm font-light leading-relaxed">
                 <dt className="font-mono text-[10px] tracking-[0.18em] uppercase text-warm-gray pt-[5px]">
                   Design
                 </dt>
@@ -299,16 +299,17 @@ export default function Navbar({
                 </dd>
               </dl>
 
-              <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-warm-gray leading-loose m-0 pt-4 border-t border-rule">
-                The Lost Person Behavior Mapper does not guarantee the
-                information provided is fully accurate. It is intended as a
-                supplemental tool for Search and Rescue efforts and cannot
-                replace other techniques. To report a missing person, contact
-                local law enforcement immediately.
-              </p>
-              <div className="pt-4 border-t border-rule">
+              <div className="mt-6 pt-5 border-t border-rule">
                 <Subscribe />
               </div>
+
+              <p className="mt-6 pt-5 border-t border-rule text-[11.5px] text-warm-gray leading-relaxed font-light m-0">
+                The Lost Person Behavior Mapper does not guarantee the
+                information provided is fully accurate. It is a supplemental
+                tool for Search and Rescue efforts and cannot replace other
+                techniques. To report a missing person, contact local law
+                enforcement immediately.
+              </p>
             </div>
           </Dialog.Popup>
         </Dialog.Portal>


### PR DESCRIPTION
## Summary
Restructured the about/credits section in the Navbar component to use a more organized definition list (dl/dt/dd) layout instead of separate paragraphs, improving readability and visual hierarchy.

## Key Changes
- Replaced paragraph-based credits layout with a semantic HTML definition list (`<dl>`) using a two-column grid layout
- Added an introductory description of the tool at the top of the about section
- Reorganized credits into labeled categories: Design, Data, Source, and Contact
- Updated styling to use smaller, uppercase labels with improved spacing and alignment
- Changed contact email from inline text to a dedicated contact section with better styling
- Adjusted typography and spacing throughout for improved visual hierarchy

## Implementation Details
- Used CSS Grid (`grid-cols-[5.5rem_1fr]`) for consistent label-to-content alignment
- Applied semantic HTML with `<dt>` (definition term) for labels and `<dd>` (definition data) for values
- Maintained existing color scheme and hover states for links
- Improved visual separation with adjusted gap spacing (`gap-x-4 gap-y-3`)
- Email link now uses monospace font and includes `break-all` for better mobile display

https://claude.ai/code/session_01XXYRoKZQm8DZREx5opmxpZ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change confined to the `About` modal markup and styling, with no logic or data-flow changes.
> 
> **Overview**
> Updates the Navbar’s `About` modal to improve readability by replacing the paragraph-style credits with a semantic two-column definition list (`dl`/`dt`/`dd`).
> 
> Adds a short introductory description of the tool, reorganizes credits into labeled sections (Design/Data/Source/Contact), and tweaks typography/spacing (including a monospace, breakable email link) while keeping the existing links and disclaimer/subscription block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2d589e53f3764e080575da4a57f3a9adfc807c5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->