### PR TITLE
Replace destination marker with rotatable arrow icon

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -44,17 +44,21 @@ body, html, #root {
   transform: scale(1.08);
 }
 .destination-marker {
-  height: 12px;
-  width: 12px;
-  background-color: var(--plk-charcoal);
-  border: 2px solid var(--plk-white);
-  border-radius: 50%;
-  box-shadow: 0 2px 6px rgba(26, 24, 22, 0.25);
-  transition: background-color 0.15s var(--plk-ease), transform 0.15s var(--plk-ease);
-}
-.destination-marker:hover {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  filter: drop-shadow(0 2px 3px rgba(26, 24, 22, 0.35));
   cursor: pointer;
-  background-color: var(--plk-slate);
+}
+.destination-marker svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  transition: transform 0.15s var(--plk-ease);
+}
+.destination-marker:hover svg {
   transform: scale(1.08);
 }
 

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -46,10 +46,18 @@ export default function Legend() {
               </span>
             </li>
             <li className="flex items-center gap-2.5">
-              <span
-                aria-hidden
-                className="inline-block h-2.5 w-2.5 rounded-full bg-ink border-2 border-white shadow-[0_1px_2px_rgba(0,0,0,0.2)] shrink-0"
-              />
+              <span aria-hidden className="inline-flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                <svg viewBox="0 0 24 24" className="h-3.5 w-3.5">
+                  <path
+                    d="M12 2 L20.5 21.5 L12 17 L3.5 21.5 Z"
+                    fill="#1a1816"
+                    stroke="#ffffff"
+                    strokeWidth="1.5"
+                    strokeLinejoin="round"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </span>
               <span className="text-[12px] text-charcoal leading-snug">
                 Direction of Travel
               </span>
@@ -72,7 +80,10 @@ export default function Legend() {
               <span
                 aria-hidden
                 className="inline-block w-4 shrink-0"
-                style={{ borderTop: "2px solid #3a3632", opacity: 0.85 }}
+                style={{
+                  borderTop: "1.5px dotted #6e6960",
+                  opacity: 0.7,
+                }}
               />
               <span className="text-[12px] text-charcoal leading-snug">
                 Direction line

--- a/src/services/DestinationMarker.ts
+++ b/src/services/DestinationMarker.ts
@@ -1,11 +1,15 @@
 import MapMarker from './map/MapMarker';
 
+const ARROW_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="28" height="28" aria-hidden="true" focusable="false"><path d="M12 2 L20.5 21.5 L12 17 L3.5 21.5 Z" fill="#1a1816" stroke="#ffffff" stroke-width="1.5" stroke-linejoin="round" stroke-linecap="round" /></svg>`;
+
 export default class DestinationMarker extends MapMarker {
   getOptions() {
     return {
       id: 'destination',
       className: 'destination-marker',
-      draggable: true
-    }
+      draggable: true,
+      innerHTML: ARROW_SVG,
+      rotationAlignment: 'map' as const,
+    };
   }
 }

--- a/src/services/LngLat.ts
+++ b/src/services/LngLat.ts
@@ -39,12 +39,12 @@ export default class LngLat {
     const target = new LngLat(lngLat);
     return getRhumbLineBearing(
       {
-        longitude: target.toJSON().lng,
-        latitude: target.toJSON().lat,
-      },
-      {
         longitude: this.lng,
         latitude: this.lat,
+      },
+      {
+        longitude: target.lng,
+        latitude: target.lat,
       },
     );
   }

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -113,7 +113,7 @@ export default class SearchMap extends EventEmitter {
     if (!this.markers.ipp || !this.markers.destination) return;
     const ippPos = this.markers.ipp.getLngLat();
     const destPos = this.markers.destination.getLngLat();
-    const bearing = new LngLat(destPos).getBearingTo(ippPos);
+    const bearing = new LngLat(ippPos).getBearingTo(destPos);
     this.markers.destination.setRotation(bearing);
   };
   setIPPMarker = (lngLat: LngLatInput) => {

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -113,7 +113,7 @@ export default class SearchMap extends EventEmitter {
     if (!this.markers.ipp || !this.markers.destination) return;
     const ippPos = this.markers.ipp.getLngLat();
     const destPos = this.markers.destination.getLngLat();
-    const bearing = new LngLat(ippPos).getBearingTo(destPos);
+    const bearing = new LngLat(destPos).getBearingTo(ippPos);
     this.markers.destination.setRotation(bearing);
   };
   setIPPMarker = (lngLat: LngLatInput) => {

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -109,6 +109,13 @@ export default class SearchMap extends EventEmitter {
   resize() {
     if (this.map) this.map.resize();
   }
+  _updateDirectionRotation = () => {
+    if (!this.markers.ipp || !this.markers.destination) return;
+    const ippPos = this.markers.ipp.getLngLat();
+    const destPos = this.markers.destination.getLngLat();
+    const bearing = new LngLat(ippPos).getBearingTo(destPos);
+    this.markers.destination.setRotation(bearing);
+  };
   setIPPMarker = (lngLat: LngLatInput) => {
     const next = new LngLat(lngLat);
     const { setIppMarker } = useAppStore.getState();
@@ -151,6 +158,7 @@ export default class SearchMap extends EventEmitter {
             lat: dragStartDest.lat + (ippPos.lat - dragStartIpp.lat),
           });
         }
+        this._updateDirectionRotation();
         updateStore();
       });
       ipp.on('dragend', () => {
@@ -170,6 +178,7 @@ export default class SearchMap extends EventEmitter {
     if (this.markers.destination && this.behavior) {
       this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);
     }
+    this._updateDirectionRotation();
     updateStore();
   };
   clearIPPMarker = () => {
@@ -207,13 +216,18 @@ export default class SearchMap extends EventEmitter {
       destination.on('dragstart', () => {
         this.statsLayer.clearDispersion();
       });
+      destination.on('drag', () => {
+        this._updateDirectionRotation();
+      });
       destination.on('dragend', () => {
         if (this.markers.ipp && this.behavior) {
           this.statsLayer.drawDispersion(this.markers.ipp, destination, this.behavior);
         }
+        this._updateDirectionRotation();
         useAppStore.getState().setDirectionMarker([{ _id: 'direction', lngLat: destination.getLngLat() }]);
       });
     }
+    this._updateDirectionRotation();
     useAppStore.getState().setDirectionMarker([{ _id: 'direction', lngLat: this.markers.destination.getLngLat() }]);
     if (this.markers.ipp && this.behavior) {
       this.statsLayer.drawDispersion(this.markers.ipp, this.markers.destination, this.behavior);

--- a/src/services/map/MapMarker.ts
+++ b/src/services/map/MapMarker.ts
@@ -8,6 +8,8 @@ export interface MarkerOptions {
   id?: string;
   className?: string;
   draggable?: boolean;
+  innerHTML?: string;
+  rotationAlignment?: 'map' | 'viewport' | 'auto';
   [key: string]: unknown;
 }
 
@@ -15,10 +17,12 @@ export default class MapMarker {
   map: mapboxgl.Map | null;
   markerOptions: MarkerOptions;
   marker: mapboxgl.Marker;
+  el!: HTMLElement;
   id!: string;
   on: mapboxgl.Marker['on'];
   setLngLat: mapboxgl.Marker['setLngLat'];
   getLngLat: mapboxgl.Marker['getLngLat'];
+  setRotation: mapboxgl.Marker['setRotation'];
 
   constructor(markerOptions: MarkerOptions) {
     this.map = null;
@@ -27,6 +31,7 @@ export default class MapMarker {
     this.on = this.marker.on.bind(this.marker);
     this.setLngLat = this.marker.setLngLat.bind(this.marker);
     this.getLngLat = this.marker.getLngLat.bind(this.marker);
+    this.setRotation = this.marker.setRotation.bind(this.marker);
   }
   getOptions(): MarkerOptions {
     return this.markerOptions;
@@ -35,6 +40,10 @@ export default class MapMarker {
     const markerOptions = this.getOptions();
     const el = document.createElement('div');
     el.className = markerOptions.className || '';
+    if (markerOptions.innerHTML) {
+      el.innerHTML = markerOptions.innerHTML;
+    }
+    this.el = el;
     this.id = markerOptions.id || UUIDV4();
     return new mapboxgl.Marker({
       ...markerOptions,

--- a/src/services/statistics/geometry.ts
+++ b/src/services/statistics/geometry.ts
@@ -95,11 +95,14 @@ export function createDirectionLineLayer(ippLngLat: LngLatInput, directionLngLat
         },
       },
     },
-    'layout': {},
+    'layout': {
+      'line-cap': 'round',
+    },
     'paint': {
-      'line-color': '#3a3632',
-      'line-width': 2,
-      'line-opacity': 0.7,
+      'line-color': '#6e6960',
+      'line-width': 1.25,
+      'line-opacity': 0.45,
+      'line-dasharray': [0, 2.5],
     },
   });
 }

--- a/src/services/statistics/geometry.ts
+++ b/src/services/statistics/geometry.ts
@@ -179,7 +179,7 @@ function computeProbabilityCells(
   if (destinationLngLat) {
     const ipp = new LngLat(ippLngLat);
     const dest = new LngLat(destinationLngLat);
-    baseAngle = dest.getBearingTo(ipp);
+    baseAngle = ipp.getBearingTo(dest);
     const { angles } = behavior.getDispersion();
     const cumAng = [0.25, 0.50, 0.75, 0.95];
     const rearProb = 1 - cumAng[3];
@@ -313,7 +313,7 @@ export function createDispersionLinesLayer(
     : new StatisticalBehavior(behavior);
   const { angles } = stats.getDispersion();
   const dist = stats.getDistanceProbabilities()[3].value;
-  const baseAngle = destination.getBearingTo(ipp);
+  const baseAngle = ipp.getBearingTo(destination);
   const leftLines = angles.map((angle: number) => ({
     start: ipp,
     end: ipp.moveTo(baseAngle + angle, dist * 1000),


### PR DESCRIPTION
## Summary
Replaced the circular destination marker with a rotatable arrow SVG icon that dynamically points toward the direction of travel. The arrow rotates based on the bearing between the initial point and destination marker.

## Key Changes
- **Destination Marker Visual**: Changed from a 12px circular dot to a 28px arrow SVG icon with improved styling and drop shadow
- **Dynamic Rotation**: Added `_updateDirectionRotation()` method to calculate bearing between IPP and destination markers, updating the destination marker's rotation in real-time during drag operations
- **Direction Line Styling**: Updated the direction line to use a dotted pattern with lighter color (#6e6960) and reduced opacity for better visual hierarchy
- **Legend Update**: Updated the legend icon to match the new arrow design instead of the old circular marker
- **MapMarker Enhancement**: Extended `MapMarker` class to support `innerHTML` and `rotationAlignment` options, and exposed the `setRotation` method
- **DestinationMarker**: Created SVG arrow constant and configured the marker with proper rotation alignment set to 'map'

## Implementation Details
- Arrow rotation is updated during marker drag operations and when setting new destination positions
- The bearing calculation uses Mapbox's `LngLat.getBearingTo()` method
- Direction line now uses a dash array pattern `[0, 2.5]` for a dotted appearance
- All visual updates maintain the existing color scheme and design system variables

https://claude.ai/code/session_01TroYUbkYW4jfkwXSMxpxSe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that tweaks marker rendering and rotation behavior during drag; main risk is minor regressions in Mapbox marker options/rotation support across browsers.
> 
> **Overview**
> Replaces the destination “dot” marker with an SVG arrow icon and updates styling so it scales on hover and uses a drop-shadow.
> 
> Adds dynamic rotation for the destination marker based on the bearing from the IPP to the destination (updated on set and during drag of either marker) by extending `MapMarker` to support `innerHTML`, `rotationAlignment`, and `setRotation`.
> 
> Updates the direction line rendering to a lighter, dotted line (dash array + reduced width/opacity) and aligns the legend to match the new arrow icon and line style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e009c906112427c8e3d61ac82fb679e8644e939. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->