### PR TITLE
Add URL state persistence for map markers and behavior

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -40,7 +40,35 @@ export default function App() {
     const behavior = profiles.getClosestBehaviorByHierarchy(behaviorKeys);
     const startPoint = urlState.ipp ?? DEFAULT_START_POINT;
 
+    let isDragging = false;
+
+    const persistCurrentState = () => {
+      const state = useAppStore.getState();
+      const ippLngLat = state.markers.byId.ipp?.lngLat;
+      const directionLngLat = state.markers.byId.direction?.lngLat;
+      writeUrlState({
+        ipp: ippLngLat
+          ? { lng: ippLngLat.lng, lat: ippLngLat.lat }
+          : undefined,
+        direction: directionLngLat
+          ? { lng: directionLngLat.lng, lat: directionLngLat.lat }
+          : undefined,
+        behaviorHierarchy: state.behavior?.hierarchy,
+      });
+    };
+
+    const handleDragStart = () => {
+      isDragging = true;
+    };
+    const handleDragEnd = () => {
+      isDragging = false;
+      persistCurrentState();
+    };
+    searchMap.on("marker:dragstart", handleDragStart);
+    searchMap.on("marker:dragend", handleDragEnd);
+
     const unsubscribe = useAppStore.subscribe((state, prevState) => {
+      if (isDragging) return;
       const ippLngLat = state.markers.byId.ipp?.lngLat;
       const directionLngLat = state.markers.byId.direction?.lngLat;
       const hierarchy = state.behavior?.hierarchy;
@@ -76,7 +104,11 @@ export default function App() {
     searchMap.on("move", () => setMapCenter(searchMap.getLngLat()));
     searchMap.load("map", startPoint);
 
-    return () => unsubscribe();
+    return () => {
+      searchMap.off("marker:dragstart", handleDragStart);
+      searchMap.off("marker:dragend", handleDragEnd);
+      unsubscribe();
+    };
   }, [setMapCenter]);
 
   useEffect(() => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,7 +9,12 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppStore } from "../store/appStore";
 import searchMap from "../store/searchMap";
 import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles";
-import { readUrlState, writeUrlState } from "../utils/urlState";
+import {
+  readUrlState,
+  sameLngLat,
+  sameStringArray,
+  writeUrlState,
+} from "../utils/urlState";
 
 const profiles = new BehaviorProfiles();
 const DEFAULT_BEHAVIOR_KEYS = ["hiker", "temperate", "mtn"];
@@ -35,9 +40,20 @@ export default function App() {
     const behavior = profiles.getClosestBehaviorByHierarchy(behaviorKeys);
     const startPoint = urlState.ipp ?? DEFAULT_START_POINT;
 
-    const unsubscribe = useAppStore.subscribe((state) => {
+    const unsubscribe = useAppStore.subscribe((state, prevState) => {
       const ippLngLat = state.markers.byId.ipp?.lngLat;
       const directionLngLat = state.markers.byId.direction?.lngLat;
+      const hierarchy = state.behavior?.hierarchy;
+      const prevIppLngLat = prevState.markers.byId.ipp?.lngLat;
+      const prevDirectionLngLat = prevState.markers.byId.direction?.lngLat;
+      const prevHierarchy = prevState.behavior?.hierarchy;
+      if (
+        sameLngLat(ippLngLat, prevIppLngLat) &&
+        sameLngLat(directionLngLat, prevDirectionLngLat) &&
+        sameStringArray(hierarchy, prevHierarchy)
+      ) {
+        return;
+      }
       writeUrlState({
         ipp: ippLngLat
           ? { lng: ippLngLat.lng, lat: ippLngLat.lat }
@@ -45,7 +61,7 @@ export default function App() {
         direction: directionLngLat
           ? { lng: directionLngLat.lng, lat: directionLngLat.lat }
           : undefined,
-        behaviorHierarchy: state.behavior?.hierarchy,
+        behaviorHierarchy: hierarchy,
       });
     });
 

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -9,8 +9,11 @@ import "mapbox-gl/dist/mapbox-gl.css";
 import { useAppStore } from "../store/appStore";
 import searchMap from "../store/searchMap";
 import BehaviorProfiles from "../services/statistics/StatisticalBehaviorProfiles";
+import { readUrlState, writeUrlState } from "../utils/urlState";
 
 const profiles = new BehaviorProfiles();
+const DEFAULT_BEHAVIOR_KEYS = ["hiker", "temperate", "mtn"];
+const DEFAULT_START_POINT = { lat: 37.775754, lng: -119.348739 };
 
 interface ContextMenuState {
   x: number;
@@ -27,17 +30,37 @@ export default function App() {
   const [activeModal, setActiveModal] = useState<ModalType>(null);
 
   useEffect(() => {
-    const behavior = profiles.getClosestBehaviorByHierarchy([
-      "hiker",
-      "temperate",
-      "mtn",
-    ]);
-    const startPoint = { lat: 37.775754, lng: -119.348739 };
+    const urlState = readUrlState();
+    const behaviorKeys = urlState.behaviorHierarchy ?? DEFAULT_BEHAVIOR_KEYS;
+    const behavior = profiles.getClosestBehaviorByHierarchy(behaviorKeys);
+    const startPoint = urlState.ipp ?? DEFAULT_START_POINT;
+
+    const unsubscribe = useAppStore.subscribe((state) => {
+      const ippLngLat = state.markers.byId.ipp?.lngLat;
+      const directionLngLat = state.markers.byId.direction?.lngLat;
+      writeUrlState({
+        ipp: ippLngLat
+          ? { lng: ippLngLat.lng, lat: ippLngLat.lat }
+          : undefined,
+        direction: directionLngLat
+          ? { lng: directionLngLat.lng, lat: directionLngLat.lat }
+          : undefined,
+        behaviorHierarchy: state.behavior?.hierarchy,
+      });
+    });
+
     setMapCenter(startPoint);
     searchMap.setBehavior(behavior);
-    searchMap.on("load", () => searchMap.setIPPMarker(startPoint));
+    searchMap.on("load", () => {
+      searchMap.setIPPMarker(startPoint);
+      if (urlState.direction) {
+        searchMap.setDestinationMarker(urlState.direction);
+      }
+    });
     searchMap.on("move", () => setMapCenter(searchMap.getLngLat()));
     searchMap.load("map", startPoint);
+
+    return () => unsubscribe();
   }, [setMapCenter]);
 
   useEffect(() => {

--- a/src/services/SearchMap.ts
+++ b/src/services/SearchMap.ts
@@ -146,6 +146,7 @@ export default class SearchMap extends EventEmitter {
         } else {
           dragStartDest = null;
         }
+        this.emit('marker:dragstart');
         updateStore();
         this.statsLayer.clearRings();
         this.statsLayer.clearDispersion();
@@ -172,6 +173,7 @@ export default class SearchMap extends EventEmitter {
         dragStartIpp = null;
         dragStartDest = null;
         updateStore();
+        this.emit('marker:dragend');
       });
     }
     if (this.behavior) this.statsLayer.drawRings(this.markers.ipp, this.behavior);
@@ -215,6 +217,7 @@ export default class SearchMap extends EventEmitter {
       if (this.map) destination.addTo(this.map);
       destination.on('dragstart', () => {
         this.statsLayer.clearDispersion();
+        this.emit('marker:dragstart');
       });
       destination.on('drag', () => {
         this._updateDirectionRotation();
@@ -225,6 +228,7 @@ export default class SearchMap extends EventEmitter {
         }
         this._updateDirectionRotation();
         useAppStore.getState().setDirectionMarker([{ _id: 'direction', lngLat: destination.getLngLat() }]);
+        this.emit('marker:dragend');
       });
     }
     this._updateDirectionRotation();

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -47,6 +47,28 @@ export function readUrlState(): UrlState {
   return state;
 }
 
+export function sameLngLat(
+  a: UrlLngLat | null | undefined,
+  b: UrlLngLat | null | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return a.lng === b.lng && a.lat === b.lat;
+}
+
+export function sameStringArray(
+  a: readonly string[] | null | undefined,
+  b: readonly string[] | null | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
 export function writeUrlState(state: UrlState): void {
   if (typeof window === 'undefined') return;
   const params = new URLSearchParams(window.location.search);

--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -1,0 +1,65 @@
+export interface UrlLngLat {
+  lng: number;
+  lat: number;
+}
+
+export interface UrlState {
+  ipp?: UrlLngLat;
+  direction?: UrlLngLat;
+  behaviorHierarchy?: string[];
+}
+
+const COORD_PRECISION = 6;
+
+function formatLngLat(lngLat: UrlLngLat): string {
+  return `${lngLat.lng.toFixed(COORD_PRECISION)},${lngLat.lat.toFixed(COORD_PRECISION)}`;
+}
+
+function parseLngLat(value: string): UrlLngLat | null {
+  const parts = value.split(',');
+  if (parts.length !== 2) return null;
+  const lng = Number.parseFloat(parts[0]);
+  const lat = Number.parseFloat(parts[1]);
+  if (!Number.isFinite(lng) || !Number.isFinite(lat)) return null;
+  if (lng < -180 || lng > 180 || lat < -90 || lat > 90) return null;
+  return { lng, lat };
+}
+
+export function readUrlState(): UrlState {
+  if (typeof window === 'undefined') return {};
+  const params = new URLSearchParams(window.location.search);
+  const state: UrlState = {};
+  const ippParam = params.get('ipp');
+  if (ippParam) {
+    const parsed = parseLngLat(ippParam);
+    if (parsed) state.ipp = parsed;
+  }
+  const dirParam = params.get('dir');
+  if (dirParam) {
+    const parsed = parseLngLat(dirParam);
+    if (parsed) state.direction = parsed;
+  }
+  const bParam = params.get('b');
+  if (bParam) {
+    const hierarchy = bParam.split(',').map((s) => s.trim()).filter(Boolean);
+    if (hierarchy.length > 0) state.behaviorHierarchy = hierarchy;
+  }
+  return state;
+}
+
+export function writeUrlState(state: UrlState): void {
+  if (typeof window === 'undefined') return;
+  const params = new URLSearchParams(window.location.search);
+  if (state.ipp) params.set('ipp', formatLngLat(state.ipp));
+  else params.delete('ipp');
+  if (state.direction) params.set('dir', formatLngLat(state.direction));
+  else params.delete('dir');
+  if (state.behaviorHierarchy && state.behaviorHierarchy.length > 0) {
+    params.set('b', state.behaviorHierarchy.join(','));
+  } else {
+    params.delete('b');
+  }
+  const search = params.toString();
+  const next = `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`;
+  window.history.replaceState(window.history.state, '', next);
+}


### PR DESCRIPTION
## Summary
This PR adds URL state persistence to the application, allowing users to share map state (initial point, direction, and behavior profile) via URL parameters. The map state is now synchronized with the URL and restored on page load.

## Key Changes
- **New utility module** (`src/utils/urlState.ts`): Implements URL state serialization and deserialization
  - `readUrlState()`: Parses URL query parameters (`ipp`, `dir`, `b`) into application state
  - `writeUrlState()`: Serializes application state back to URL parameters
  - Coordinate validation: Ensures longitude (-180 to 180) and latitude (-90 to 90) bounds
  - Precision: Coordinates are formatted to 6 decimal places

- **App component updates** (`src/components/App.tsx`):
  - Reads initial state from URL on mount and applies defaults if not present
  - Subscribes to app store changes and updates URL whenever markers or behavior change
  - Restores direction marker from URL if present
  - Properly cleans up store subscription on unmount

## Implementation Details
- URL parameters: `ipp` (initial point), `dir` (direction), `b` (behavior hierarchy)
- Coordinates are stored as comma-separated `lng,lat` pairs
- Behavior hierarchy is stored as comma-separated values
- Uses `window.history.replaceState()` to update URL without creating history entries
- Includes SSR safety checks (`typeof window === 'undefined'`)
- Default behavior: `["hiker", "temperate", "mtn"]`
- Default start point: Yosemite area (37.775754, -119.348739)

https://claude.ai/code/session_011HcRtrZVEr23wRf5CChhDk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces continuous URL synchronization via a global store subscription and restores state on load, which can affect initialization order and cause unexpected URL churn/perf issues if store updates are frequent.
> 
> **Overview**
> Adds shareable URL state for the map by introducing `src/utils/urlState.ts` to parse/serialize query params for IPP (`ipp`), destination (`dir`), and behavior hierarchy (`b`) with coordinate validation and fixed precision.
> 
> Updates `App.tsx` to initialize behavior and start point from the URL (falling back to defaults), restore the destination marker on map load, and subscribe to `useAppStore` changes to keep the URL updated via `history.replaceState` (with cleanup on unmount).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a849c0061d8323928721237d2d672806ff05ae6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->